### PR TITLE
ci(repo): fix vcan module install on GitHub-hosted runners

### DIFF
--- a/.github/actions/bring-up-vcan/action.yml
+++ b/.github/actions/bring-up-vcan/action.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Composite action: bring up a vcan0 interface for the zero-hardware test path
+# (ADR-005, C-5, FW-REQ-031). Used by every CI job at T2 or above.
+#
+# The vcan kernel module is not loaded by default on GitHub's ubuntu-latest
+# runners and lives in the linux-modules-extra package rather than the base
+# image (verified against the runner's own kernel — modprobe fails with
+# "Module vcan not found" otherwise), so that install has to happen first.
+
+name: Bring up vcan0
+description: Loads the vcan kernel module and brings up a vcan0 interface
+
+runs:
+  using: composite
+  steps:
+    - name: Install and load the vcan kernel module
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+        sudo modprobe vcan
+    - name: Create and bring up vcan0
+      shell: bash
+      run: |
+        sudo ip link add dev vcan0 type vcan
+        sudo ip link set up vcan0
+        ip -details link show vcan0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,7 @@ jobs:
       # The entire internal suite has to run here, on a stock runner, with
       # nothing plugged in — that is both FW-REQ-031 and the contributor
       # onboarding promise.
-      - name: Bring up vcan0
-        run: |
-          sudo modprobe vcan
-          sudo ip link add dev vcan0 type vcan
-          sudo ip link set up vcan0
-          ip -details link show vcan0
+      - uses: ./.github/actions/bring-up-vcan
       - run: pip install -e ".[dev]"
       - run: pytest tests/integration -v
         env:
@@ -99,11 +94,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Bring up vcan0
-        run: |
-          sudo modprobe vcan
-          sudo ip link add dev vcan0 type vcan
-          sudo ip link set up vcan0
+      - uses: ./.github/actions/bring-up-vcan
       - run: pip install -e ".[dev]"
       - name: Fixture integrity (oracle library)
         run: python tools/check_fixtures.py
@@ -124,11 +115,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Bring up vcan0
-        run: |
-          sudo modprobe vcan
-          sudo ip link add dev vcan0 type vcan
-          sudo ip link set up vcan0
+      - uses: ./.github/actions/bring-up-vcan
       - run: pip install -e ".[dev]"
       # Empty until the first hardening loop; see the note in t3-differential.
       - run: pytest tests/property -v || [ $? -eq 5 ]
@@ -144,11 +131,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Bring up vcan0
-        run: |
-          sudo modprobe vcan
-          sudo ip link add dev vcan0 type vcan
-          sudo ip link set up vcan0
+      - uses: ./.github/actions/bring-up-vcan
       - run: pip install -e ".[dev]"
       - run: pytest --cov=tapwright --cov-branch --cov-report=xml --cov-report=term-missing
         env:


### PR DESCRIPTION
## What this changes and why

`main`'s CI is currently red: PR #6 was merged before this fix was pushed to that branch, so `main`'s `t2-integration`, `t3-differential`, `t4-property`, and `coverage-ratchet` jobs are all failing on

```
modprobe: FATAL: Module vcan not found in directory /lib/modules/6.17.0-1022-azure
```

The `vcan` kernel module isn't in GitHub's `ubuntu-latest` base image — it ships in `linux-modules-extra`, which needs an explicit install first. Cherry-picked from `chore/loop-substrate-inf-02-06` (541e44c), which had this fix but landed after the PR was already merged.

Factored the fix into a composite action (`.github/actions/bring-up-vcan`) rather than repeating it in the four jobs that need `vcan`.

## Type of change
- [x] Bug fix (CI)

## Checklist
- [x] DCO sign-off
- [x] `ruff check`, `ruff format --check`, `mypy` clean; SPDX check clean
- [x] Full local suite green (41 passed, 2 skipped — vcan-dependent tests skip on this non-Linux dev machine, verified in CI itself)
- [ ] CHANGELOG — no entry; this is a fix to code that hasn't shipped in a release yet

## How this was tested
Locally: ruff/mypy/SPDX all clean, full pytest suite green. The actual fix (module install) can only be confirmed by this PR's own CI run on a real runner — that's the point of merging it.