### PR TITLE
fix(repo): call the vcan_channel fixture, not the old function

### DIFF
--- a/tests/integration/test_vcan_substrate.py
+++ b/tests/integration/test_vcan_substrate.py
@@ -44,11 +44,11 @@ def test_frame_sent_on_vcan_is_received(vcan_channel):
     payload = b"\xde\xad\xbe\xef"
 
     with socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as receiver:
-        receiver.bind((vcan_channel(),))
+        receiver.bind((vcan_channel,))
         receiver.settimeout(2.0)
 
         with socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as sender:
-            sender.bind((vcan_channel(),))
+            sender.bind((vcan_channel,))
             sender.send(struct.pack(CAN_FRAME_FMT, can_id, len(payload), payload))
 
         frame = receiver.recv(CAN_FRAME_SIZE)


### PR DESCRIPTION
## What this changes and why

`main` is red again after PR #7 merged: that PR was merged (12:40:05) a
few seconds before its second commit — the one fixing this exact bug —
was pushed. `main`'s `t2-integration` and `coverage-ratchet` jobs are
failing on:

```
TypeError: 'str' object is not callable
```

`test_frame_sent_on_vcan_is_received` still called `vcan_channel()` in
two places, left over from before `conftest.py`'s `vcan_channel` became
a pytest fixture rather than a plain function.

**Recommend holding this one for CI to go green before merging** — the
last two merges landed slightly ahead of a still-running fix, which is
what produced this PR and the one before it. Once this is in, `main`
should be fully green on a real run.

## Type of change
- [x] Bug fix (tests)

## Checklist
- [x] DCO sign-off
- [x] `ruff check`, `ruff format --check` clean
- [x] Full local suite green (41 passed, 2 skipped for vcan-absent-on-Windows)

## How this was tested
Locally, plus this PR's own CI run — the only way to confirm the vcan
integration path actually works on a real Linux runner.