### PR TITLE
feat(diag): ISO-TP transport over hal.Bus (DIAG-01, TOOL-REQ-022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **ISO-TP transport over `hal.Bus`** (DIAG-01, `TOOL-REQ-022` transport
+  half; #11): `tapwright.diag.isotp_transport.IsoTpTransport` wraps
+  `can-isotp`'s `isotp.TransportLayer`, bridged to `tapwright.hal.Bus` via
+  `rxfn`/`txfn` adapters rather than opening its own `python-can` bus — L2
+  built on L0, per `docs/architecture.md`'s layering. Multi-frame
+  segmentation/reassembly verified byte-identical to a stock
+  `isotp.CanStack` peer, both directions, up to ~4000-byte payloads;
+  out-of-sequence Consecutive Frames surface as `TransportProtocolError`
+  rather than a silently wrong reassembly. `tapwright.diag.errors` adds the
+  `DiagError` hierarchy, mirroring `hal.errors`' convention.
 - **HAL: `Bus` abstraction + SocketCAN/`vcan` backend** (HAL-01/HAL-02,
   `TOOL-REQ-001` partial, `TOOL-REQ-002`, `TOOL-REQ-008`, `TOOL-REQ-009`,
   `TOOL-REQ-010`; #3): `open_bus()` + `Bus` over SocketCAN (real interfaces

--- a/LOOPS.md
+++ b/LOOPS.md
@@ -106,7 +106,7 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 
 | ID | Goal | Type | Tier | It. | Pri | Status |
 |---|---|---|---|---|---|---|
-| DIAG-01 | ISO-TP transport via `can-isotp` (MIT — verified) | W | T3 | 5 | Must | 🔴 |
+| DIAG-01 | ISO-TP transport via `can-isotp` (MIT — verified) | W | T3 | 5 | Must | 🔵 |
 | DIAG-02 | UDS client core via `udsoncan` | W | T4 | 8 | Must | 🔴 |
 | DIAG-03 | DoIP transport via `doipclient` + entity discovery | W | T3 | 6 | Must | 🔴 |
 | DIAG-04 | Transport-agnostic connection abstraction (SOVD-shaped) | I | T3 | 6 | Must | 🔴 |
@@ -115,6 +115,19 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 | DIAG-07 | SOVD client (REST/JSON, ISO 17978) | P | T3 | 8 | Should | 🔴 |
 | DIAG-08 | C-10 guardrail: `0x27` mechanics only; CI scan blocks key derivation | H | T1 | 3 | Must | 🔵 landed early with the substrate (`tools/check_forbidden.py`); the deliberate red-team commit that proves CI rejects it is still owed |
 | DIAG-09 | Malformed-response hardening: NRCs, timeouts, truncated frames | H | T4 | 7 | Must | 🔴 |
+
+> **DIAG-01** (PR #12): `IsoTpTransport` built on `hal.Bus` via `rxfn`/`txfn`
+> adapters, not a raw `python-can` bus — deliberately, so L2 sits on L0
+> (`docs/architecture.md`). All 12 T3 cases green against a stock
+> `isotp.CanStack` peer, both directions, up to ~4000-byte payloads. CI
+> caught a real bug: `_txfn` read `message.extended_id`, but
+> `isotp.CanMessage`'s stored attribute is `is_extended_id` — every send
+> raised `AttributeError` inside `can-isotp`'s own thread, silently killing
+> it with zero visible failure until CI's differential oracle caught it (8 of
+> 12 cases failed until fixed). **Known inconsistency, not yet resolved**:
+> `tools/virtual_ecu` (INF-05) still opens its own `python-can` bus directly
+> rather than building on `hal.Bus` — it predates HAL-01/02 and hasn't been
+> revisited.
 
 > **DIAG-06 has a weak oracle.** ODX semantic correctness cannot be fully
 > machine-verified: the loop closes on *structural* correctness, and semantic

--- a/src/tapwright/diag/__init__.py
+++ b/src/tapwright/diag/__init__.py
@@ -11,5 +11,11 @@ projects like Gallia) to wrap it later without forking it. See
 ARCHITECTURE.md at the repository root before changing this module's
 public surface.
 
-Not yet implemented — this is scaffolding for Milestones M1-M2.
+Implemented so far: `virtual_ecu` (INF-05, the zero-hardware UDS responder)
+and `isotp_transport` (DIAG-01, ISO-TP over `hal.Bus`). Both are accessed
+directly (`tapwright.diag.virtual_ecu`, `tapwright.diag.isotp_transport`)
+rather than re-exported here, so importing `tapwright.diag` itself stays
+cheap — it doesn't pull in `can`/`isotp`/`udsoncan` unless a submodule that
+actually needs them is imported. The UDS client (DIAG-02) and DoIP
+transport (DIAG-03) are not yet built.
 """

--- a/src/tapwright/diag/errors.py
+++ b/src/tapwright/diag/errors.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Errors raised at the L2 diagnostics boundary.
+
+Mirrors `hal.errors`' convention: every failure `diag/`'s public API raises
+is a `DiagError` subclass, so a caller never has to catch a
+transport/protocol-library-internal exception type to handle a diagnostics
+failure.
+"""
+
+from __future__ import annotations
+
+
+class DiagError(Exception):
+    """Base class for every error raised by tapwright.diag's public API."""
+
+
+class TransportClosedError(DiagError):
+    """A transport handle was used after close()."""
+
+
+class TransportConfigError(DiagError):
+    """Invalid transport configuration — raised before any OS-level
+    resource is touched, matching hal.errors.BusConfigError's contract."""
+
+
+class TransportProtocolError(DiagError):
+    """The underlying transport protocol detected a malformed exchange
+    (e.g. an out-of-sequence ISO-TP Consecutive Frame) — surfaced here
+    rather than silently producing a wrong or incomplete payload, per the
+    "silently wrong decode" failure mode the verification ladder (plan §3)
+    exists to catch."""

--- a/src/tapwright/diag/isotp_transport.py
+++ b/src/tapwright/diag/isotp_transport.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""ISO-TP (ISO 15765-2) transport for L2, built on `tapwright.hal.Bus`
+(DIAG-01, `TOOL-REQ-022`'s transport half).
+
+Wraps `can-isotp`'s `isotp.TransportLayer` — the segmentation, reassembly,
+and flow-control state machine is entirely the library's; this module's only
+job is bridging it to `hal.Bus` via `_rxfn`/`_txfn` adapters that convert
+between `hal.Frame` and `isotp.CanMessage`. That is a deliberate layering
+choice: L2 sits on L0 (`docs/architecture.md`), so this does *not* open its
+own `python-can` bus the way `tools/virtual_ecu` does (a shortcut taken
+before HAL existed — see the scope note on issue #11).
+
+`can-isotp` is MIT (verified, `licences.toml`) — no isolation question, only
+`python-can` (LGPL-3.0, dependency-only per C-9) carries that.
+"""
+
+from __future__ import annotations
+
+import isotp
+
+from tapwright.hal import Bus, Frame
+
+from .errors import TransportClosedError, TransportProtocolError
+
+
+class IsoTpTransport:
+    """A byte-stream ISO-TP transport over a `tapwright.hal.Bus`.
+
+    `send`/`recv` deal in whole ISO-TP payloads (bytes) — the multi-frame
+    handshake, if any, is invisible to the caller. Kept deliberately simple:
+    per `docs/architecture.md` §4, this is not itself the request/response
+    interception point a future fuzzer would hook into (that's DIAG-02's
+    UDS client, one layer up), but its shape must not preclude one being
+    added later without a breaking change.
+    """
+
+    def __init__(
+        self,
+        bus: Bus,
+        *,
+        rxid: int,
+        txid: int,
+        addressing_mode: isotp.AddressingMode = isotp.AddressingMode.Normal_11bits,
+        params: dict[str, object] | None = None,
+    ) -> None:
+        self._bus = bus
+        self._closed = False
+        self._protocol_error: BaseException | None = None
+
+        address = isotp.Address(addressing_mode, rxid=rxid, txid=txid)
+        self._stack = isotp.TransportLayer(
+            rxfn=self._rxfn,
+            txfn=self._txfn,
+            address=address,
+            error_handler=self._on_protocol_error,
+            params=params,
+        )
+        self._stack.start()
+
+    def send(self, data: bytes) -> None:
+        if self._closed:
+            raise TransportClosedError("cannot send on a transport after close()")
+        self._stack.send(bytes(data))
+
+    def recv(self, timeout: float | None = None) -> bytes | None:
+        """Block for up to `timeout` seconds for one fully reassembled ISO-TP
+        payload. Returns None on timeout with no traffic — matches
+        `hal.Bus.recv`'s own contract (NFR-003: a prompt, non-hanging
+        timeout, not an exception).
+        """
+        if self._closed:
+            raise TransportClosedError("cannot recv on a transport after close()")
+
+        result = self._stack.recv(block=True, timeout=timeout)
+
+        if self._protocol_error is not None:
+            error, self._protocol_error = self._protocol_error, None
+            raise TransportProtocolError(str(error)) from error
+
+        return bytes(result) if result is not None else None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._stack.stop()
+
+    def __enter__(self) -> IsoTpTransport:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    # -- hal.Bus <-> isotp.CanMessage bridge --------------------------------
+
+    def _rxfn(self, timeout: float) -> isotp.CanMessage | None:
+        try:
+            frame = self._bus.recv(timeout=timeout)
+        except Exception:
+            # The bus was closed out from under this transport (e.g. by
+            # another thread) while a receive was in flight. Reported to the
+            # isotp background thread as "nothing arrived" rather than
+            # letting an exception escape into its internals — the caller
+            # already gets a clear TransportClosedError the next time it
+            # calls send()/recv() itself, per test_underlying_hal_bus_closed_
+            # does_not_hang_recv.
+            return None
+        if frame is None:
+            return None
+        return isotp.CanMessage(
+            arbitration_id=frame.arbitration_id,
+            data=frame.data,
+            extended_id=frame.is_extended_id,
+            is_fd=frame.is_fd,
+        )
+
+    def _txfn(self, message: isotp.CanMessage) -> None:
+        self._bus.send(
+            Frame(
+                arbitration_id=message.arbitration_id,
+                data=bytes(message.data),
+                is_extended_id=message.extended_id,
+                is_fd=message.is_fd,
+            )
+        )
+
+    def _on_protocol_error(self, error: Exception) -> None:
+        # Called from can-isotp's own background thread. Stashed rather than
+        # raised here — there is no caller frame to raise into — and
+        # re-raised from the next recv() call, per
+        # test_out_of_sequence_consecutive_frame_is_reported_not_silently_
+        # misassembled.
+        self._protocol_error = error

--- a/src/tapwright/diag/isotp_transport.py
+++ b/src/tapwright/diag/isotp_transport.py
@@ -116,11 +116,18 @@ class IsoTpTransport:
         )
 
     def _txfn(self, message: isotp.CanMessage) -> None:
+        # isotp.CanMessage's constructor parameter is named extended_id, but
+        # the stored attribute (per its __slots__) is is_extended_id — using
+        # the constructor's name here raised AttributeError on every send,
+        # silently killing can-isotp's internal sending thread with no
+        # traceback visible to a caller. Caught by this branch's own CI: a
+        # stock isotp.CanStack peer never observed anything sent through
+        # IsoTpTransport.send().
         self._bus.send(
             Frame(
                 arbitration_id=message.arbitration_id,
                 data=bytes(message.data),
-                is_extended_id=message.extended_id,
+                is_extended_id=message.is_extended_id,
                 is_fd=message.is_fd,
             )
         )

--- a/tests/differential/test_isotp_transport.py
+++ b/tests/differential/test_isotp_transport.py
@@ -1,85 +1,145 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test plan for DIAG-01 / TOOL-REQ-022's transport half — the ISO-TP
-transport wrapping `can-isotp` over `tapwright.hal.Bus`.
+"""T3 differential tests for DIAG-01 / TOOL-REQ-022's transport half — the
+ISO-TP transport wrapping `can-isotp` over `tapwright.hal.Bus`.
 
-Implements #11. T3 differential tier: every case drives our transport against
-a stock `isotp.CanStack` used directly on a raw `python-can` bus on the same
-`vcan` interface — that pairing is this loop's oracle, per the same
+Implements #11. Every case drives `IsoTpTransport` against a stock
+`isotp.CanStack` used directly on a raw `python-can` bus on the same `vcan`
+interface — that pairing is this loop's oracle, per the same
 independently-authored-reference discipline used for INF-05 (see
-`docs/inf-05-simulator-reuse-evaluation.md`). Our wrapper's segmented and
-reassembled payloads must be byte-identical to what the library produces
-when driven directly, in both directions.
-
-TOOL-REQ-022's acceptance criterion (the half this loop owns): a UDS client
-needs a working ISO-TP transport before DIAG-02 can read a DID at all.
+`docs/inf-05-simulator-reuse-evaluation.md`).
 
 ## Scope notes (posted in full to #11; kept here as a pointer)
 
-- Layering: this transport is built on `tapwright.hal.Bus` via small
-  `rxfn`/`txfn` adapters bridging `hal.Frame` <-> `isotp.CanMessage`, *not*
-  by opening its own `python-can` bus directly — unlike `tools/virtual_ecu`
-  (INF-05), which took that shortcut before HAL existed. Flagged as a known
-  inconsistency to revisit separately; out of this issue's blast radius.
-- Addressing: Normal_11bits only, matching the virtual ECU's own addressing.
-  Extended/mixed addressing is a follow-up, not required for DIAG-02.
-- Flow-control state machine itself is `can-isotp`'s job, not reimplemented
-  here — this loop tests that our HAL bridge doesn't corrupt or drop what
-  the library already does correctly.
-- **L2 API-cleanliness note** (test-plan skill step 5): this transport is
-  not itself the request/response interception point `docs/architecture.md`
-  §4 requires — that's DIAG-02's UDS client, sitting one layer up. Nothing
-  here tests that interception point (it doesn't exist yet), but this
-  transport's `send`/`recv` shape is kept simple and inspectable enough that
-  a future interception hook can sit between the UDS client and this
-  transport without this class needing to change — noted so it isn't
-  rediscovered as a rewrite requirement later, per §4's own instruction.
+- Layering: built on `tapwright.hal.Bus` via `rxfn`/`txfn` adapters, not a
+  raw `python-can` bus — unlike `tools/virtual_ecu` (INF-05), which took
+  that shortcut before HAL existed. Flagged as a known inconsistency to
+  revisit separately, not fixed here.
+- Normal_11bits addressing only; extended/mixed addressing deferred.
+- **L2 API-cleanliness note**: this transport is not `docs/architecture.md`
+  §4's interception point (that's DIAG-02, one layer up) — noted so the
+  constraint isn't rediscovered later. Kept simple enough for a future hook
+  to sit between the UDS client and this transport without this class
+  needing to change.
 """
 
 from __future__ import annotations
 
+import contextlib
+import time
+
+import can
+import isotp
 import pytest
+
+from tapwright.diag.errors import TransportClosedError, TransportProtocolError
+from tapwright.diag.isotp_transport import IsoTpTransport
+from tapwright.hal import open_bus
 
 pytestmark = pytest.mark.requires_vcan
 
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #11)")
+# Arbitration IDs from *our transport's* perspective: it listens on
+# DEFAULT_RXID, transmits on DEFAULT_TXID. A peer therefore listens on
+# DEFAULT_TXID and transmits on DEFAULT_RXID.
+DEFAULT_RXID = 0x7E0
+DEFAULT_TXID = 0x7E8
 
-# ---------------------------------------------------------------------------
-# Happy path — TOOL-REQ-022's transport half
-# ---------------------------------------------------------------------------
 
-
-@SKIP
-def test_single_frame_send_reaches_a_stock_isotp_peer(vcan_channel):
-    """A payload small enough for one ISO-TP frame (<=7 bytes on classic
-    CAN), sent through our transport, arrives byte-identical at a peer using
-    isotp.CanStack directly — the oracle for the send direction.
+@contextlib.contextmanager
+def stock_isotp_peer(channel: str, *, rxid: int, txid: int):
+    """A stock `isotp.CanStack` peer on a raw `python-can` bus — this file's
+    oracle. `rxid`/`txid` are from the peer's own perspective.
     """
+    bus = can.Bus(interface="socketcan", channel=channel, receive_own_messages=False)
+    stack = isotp.CanStack(
+        bus=bus,
+        address=isotp.Address(isotp.AddressingMode.Normal_11bits, rxid=rxid, txid=txid),
+        error_handler=lambda _error: None,
+    )
+    stack.start()
+    try:
+        yield stack
+    finally:
+        stack.stop()
+        bus.shutdown()
 
 
-@SKIP
+@contextlib.contextmanager
+def our_transport(channel: str, *, rxid: int = DEFAULT_RXID, txid: int = DEFAULT_TXID):
+    bus = open_bus(backend="socketcan", channel=channel)
+    transport = IsoTpTransport(bus, rxid=rxid, txid=txid)
+    try:
+        yield transport
+    finally:
+        transport.close()
+        bus.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_single_frame_send_reaches_a_stock_isotp_peer(vcan_channel):
+    """A payload small enough for one ISO-TP frame, sent through our
+    transport, arrives byte-identical at a peer using isotp.CanStack
+    directly — the oracle for the send direction.
+    """
+    payload = b"\x01\x02\x03"
+    with (
+        stock_isotp_peer(vcan_channel, rxid=DEFAULT_TXID, txid=DEFAULT_RXID) as peer,
+        our_transport(vcan_channel) as transport,
+    ):
+        transport.send(payload)
+        received = peer.recv(block=True, timeout=2.0)
+    assert received is not None
+    assert bytes(received) == payload
+
+
 def test_multi_frame_send_reaches_a_stock_isotp_peer(vcan_channel):
     """A payload beyond one frame, sent through our transport, triggers the
     First-Frame/Flow-Control/Consecutive-Frame handshake and arrives
-    byte-identical at a stock isotp.CanStack peer — proves our HAL bridge
-    doesn't break segmentation.
+    byte-identical at a stock isotp.CanStack peer.
     """
+    payload = bytes(range(30))
+    with (
+        stock_isotp_peer(vcan_channel, rxid=DEFAULT_TXID, txid=DEFAULT_RXID) as peer,
+        our_transport(vcan_channel) as transport,
+    ):
+        transport.send(payload)
+        received = peer.recv(block=True, timeout=2.0)
+    assert received is not None
+    assert bytes(received) == payload
 
 
-@SKIP
 def test_single_frame_received_from_a_stock_isotp_peer(vcan_channel):
     """Reverse direction: a stock isotp.CanStack peer sends a single-frame
     payload; our transport reassembles (trivially, for one frame) and
     returns it byte-identical.
     """
+    payload = b"\xaa\xbb"
+    with (
+        stock_isotp_peer(vcan_channel, rxid=DEFAULT_TXID, txid=DEFAULT_RXID) as peer,
+        our_transport(vcan_channel) as transport,
+    ):
+        peer.send(payload)
+        received = transport.recv(timeout=2.0)
+    assert received == payload
 
 
-@SKIP
 def test_multi_frame_received_from_a_stock_isotp_peer(vcan_channel):
     """Reverse direction, multi-frame: a stock isotp.CanStack peer sends a
     payload requiring segmentation; our transport correctly handles flow
-    control and reassembles it byte-identical to what was sent.
+    control and reassembles it byte-identical.
     """
+    payload = bytes(range(40))
+    with (
+        stock_isotp_peer(vcan_channel, rxid=DEFAULT_TXID, txid=DEFAULT_RXID) as peer,
+        our_transport(vcan_channel) as transport,
+    ):
+        peer.send(payload)
+        received = transport.recv(timeout=2.0)
+    assert received == payload
 
 
 # ---------------------------------------------------------------------------
@@ -87,42 +147,74 @@ def test_multi_frame_received_from_a_stock_isotp_peer(vcan_channel):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_payload_exactly_at_single_frame_boundary(vcan_channel):
     """Exactly 7 bytes (classic CAN's single-frame max with a 1-byte PCI)
-    round-trips as a single frame, not an unnecessary multi-frame sequence.
-    """
+    round-trips as a single frame."""
+    payload = bytes(range(7))
+    with (
+        stock_isotp_peer(vcan_channel, rxid=DEFAULT_TXID, txid=DEFAULT_RXID) as peer,
+        our_transport(vcan_channel) as transport,
+    ):
+        transport.send(payload)
+        received = peer.recv(block=True, timeout=2.0)
+    assert received is not None
+    assert bytes(received) == payload
 
 
-@SKIP
 def test_payload_one_byte_over_single_frame_boundary_triggers_segmentation(vcan_channel):
-    """8 bytes — one byte past the single-frame boundary — correctly
-    triggers multi-frame segmentation rather than truncating or erroring.
-    """
+    """8 bytes — one past the single-frame boundary — round-trips correctly,
+    proving segmentation kicks in rather than truncating or erroring."""
+    payload = bytes(range(8))
+    with (
+        stock_isotp_peer(vcan_channel, rxid=DEFAULT_TXID, txid=DEFAULT_RXID) as peer,
+        our_transport(vcan_channel) as transport,
+    ):
+        transport.send(payload)
+        received = peer.recv(block=True, timeout=2.0)
+    assert received is not None
+    assert bytes(received) == payload
 
 
-@SKIP
 def test_large_payload_near_classic_isotp_maximum_round_trips(vcan_channel):
     """A payload approaching classic ISO-TP's 4095-byte maximum round-trips
     correctly — proves flow-control block-size/separation-time handling
-    works across many consecutive frames, not just two or three.
-    """
+    works across many consecutive frames, not just two or three."""
+    payload = bytes(i % 256 for i in range(4000))
+    with (
+        stock_isotp_peer(vcan_channel, rxid=DEFAULT_TXID, txid=DEFAULT_RXID) as peer,
+        our_transport(vcan_channel) as transport,
+    ):
+        transport.send(payload)
+        received = peer.recv(block=True, timeout=10.0)
+    assert received is not None
+    assert bytes(received) == payload
 
 
-@SKIP
 def test_configurable_arbitration_ids_are_not_hardcoded(vcan_channel):
     """A transport opened with a non-default rx/tx ID pair works correctly
     — arbitration IDs are a construction-time config, matching HAL's own
-    "swap is a config change" property (TOOL-REQ-001) carried up to L2.
-    """
+    "swap is a config change" property carried up to L2."""
+    rxid, txid = 0x123, 0x456
+    payload = b"\x99"
+    with (
+        stock_isotp_peer(vcan_channel, rxid=txid, txid=rxid) as peer,
+        our_transport(vcan_channel, rxid=rxid, txid=txid) as transport,
+    ):
+        transport.send(payload)
+        received = peer.recv(block=True, timeout=2.0)
+    assert received is not None
+    assert bytes(received) == payload
 
 
-@SKIP
 def test_recv_times_out_cleanly_with_no_traffic(vcan_channel):
-    """Derived from NFR-003 (test determinism), same boundary HAL-01/02
-    already established for its own recv(): no traffic means a prompt
-    timeout, not a hang.
-    """
+    """No traffic means a prompt timeout, not a hang — same boundary
+    HAL-01/02 already established for hal.Bus.recv()."""
+    with our_transport(vcan_channel) as transport:
+        start = time.monotonic()
+        result = transport.recv(timeout=0.2)
+        elapsed = time.monotonic() - start
+    assert result is None
+    assert elapsed < 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -130,29 +222,76 @@ def test_recv_times_out_cleanly_with_no_traffic(vcan_channel):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_out_of_sequence_consecutive_frame_is_reported_not_silently_misassembled(vcan_channel):
     """A peer sending Consecutive Frames with a wrong sequence number is a
-    malformed transfer. Our transport must surface this as an error (or a
-    dropped/None result with the error visible via a callback/log) rather
+    malformed transfer. Our transport must surface this as an error rather
     than silently assembling a wrong payload — the "silently wrong decode"
-    failure mode the whole verification ladder exists to catch (plan §3).
+    failure mode the verification ladder exists to catch (plan §3).
     """
+    with our_transport(vcan_channel) as transport:
+        raw = can.Bus(interface="socketcan", channel=vcan_channel, receive_own_messages=False)
+        try:
+            # First Frame declaring a 12-byte payload (forces multi-frame).
+            raw.send(
+                can.Message(
+                    arbitration_id=DEFAULT_RXID,
+                    data=bytes([0x10, 0x0C]) + bytes(6),
+                    is_extended_id=False,
+                )
+            )
+
+            # Our transport, as receiver, must answer with Flow Control
+            # before any Consecutive Frame is valid.
+            flow_control = raw.recv(timeout=2.0)
+            assert flow_control is not None
+            assert flow_control.data[0] >> 4 == 0x3, "expected a Flow Control response"
+
+            # Consecutive Frame with the wrong sequence number: the first CF
+            # must be sequence 1; send 3 instead.
+            raw.send(
+                can.Message(
+                    arbitration_id=DEFAULT_RXID,
+                    data=bytes([0x23]) + bytes(range(6)),
+                    is_extended_id=False,
+                )
+            )
+
+            with pytest.raises(TransportProtocolError):
+                transport.recv(timeout=2.0)
+        finally:
+            raw.shutdown()
 
 
-@SKIP
 def test_send_after_close_raises_clear_error(vcan_channel):
     """Using a transport handle after close() raises a clear, typed error —
-    matching the HalError convention HAL-01 already established, not a bare
-    exception surfaced from deep inside can-isotp.
-    """
+    matching the HalError convention HAL-01 already established."""
+    bus = open_bus(backend="socketcan", channel=vcan_channel)
+    transport = IsoTpTransport(bus, rxid=DEFAULT_RXID, txid=DEFAULT_TXID)
+    transport.close()
+    try:
+        with pytest.raises(TransportClosedError):
+            transport.send(b"\x01")
+    finally:
+        bus.shutdown()
 
 
-@SKIP
 def test_underlying_hal_bus_closed_does_not_hang_recv(vcan_channel):
     """If the tapwright.hal.Bus underneath is closed while a recv() is
-    in-flight (e.g. another thread calls bus.shutdown()), recv() returns or
-    raises promptly rather than blocking forever — a hang here would be a
-    much worse test-suite failure mode than a clean error, since it doesn't
-    even produce a readable pytest failure, just a stuck CI job.
-    """
+    in-flight, recv() returns or raises promptly rather than blocking
+    forever — a hang here is a much worse failure mode than a clean error,
+    since it doesn't even produce a readable pytest failure, just a stuck
+    CI job."""
+    bus = open_bus(backend="socketcan", channel=vcan_channel)
+    transport = IsoTpTransport(bus, rxid=DEFAULT_RXID, txid=DEFAULT_TXID)
+    bus.shutdown()
+
+    start = time.monotonic()
+    try:
+        result = transport.recv(timeout=1.0)
+        assert result is None
+    except Exception:
+        pass  # raising is also an acceptable outcome; hanging is not
+    elapsed = time.monotonic() - start
+
+    transport.close()
+    assert elapsed < 3.0

--- a/tests/differential/test_isotp_transport.py
+++ b/tests/differential/test_isotp_transport.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test plan for DIAG-01 / TOOL-REQ-022's transport half — the ISO-TP
+transport wrapping `can-isotp` over `tapwright.hal.Bus`.
+
+Implements #11. T3 differential tier: every case drives our transport against
+a stock `isotp.CanStack` used directly on a raw `python-can` bus on the same
+`vcan` interface — that pairing is this loop's oracle, per the same
+independently-authored-reference discipline used for INF-05 (see
+`docs/inf-05-simulator-reuse-evaluation.md`). Our wrapper's segmented and
+reassembled payloads must be byte-identical to what the library produces
+when driven directly, in both directions.
+
+TOOL-REQ-022's acceptance criterion (the half this loop owns): a UDS client
+needs a working ISO-TP transport before DIAG-02 can read a DID at all.
+
+## Scope notes (posted in full to #11; kept here as a pointer)
+
+- Layering: this transport is built on `tapwright.hal.Bus` via small
+  `rxfn`/`txfn` adapters bridging `hal.Frame` <-> `isotp.CanMessage`, *not*
+  by opening its own `python-can` bus directly — unlike `tools/virtual_ecu`
+  (INF-05), which took that shortcut before HAL existed. Flagged as a known
+  inconsistency to revisit separately; out of this issue's blast radius.
+- Addressing: Normal_11bits only, matching the virtual ECU's own addressing.
+  Extended/mixed addressing is a follow-up, not required for DIAG-02.
+- Flow-control state machine itself is `can-isotp`'s job, not reimplemented
+  here — this loop tests that our HAL bridge doesn't corrupt or drop what
+  the library already does correctly.
+- **L2 API-cleanliness note** (test-plan skill step 5): this transport is
+  not itself the request/response interception point `docs/architecture.md`
+  §4 requires — that's DIAG-02's UDS client, sitting one layer up. Nothing
+  here tests that interception point (it doesn't exist yet), but this
+  transport's `send`/`recv` shape is kept simple and inspectable enough that
+  a future interception hook can sit between the UDS client and this
+  transport without this class needing to change — noted so it isn't
+  rediscovered as a rewrite requirement later, per §4's own instruction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.requires_vcan
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #11)")
+
+# ---------------------------------------------------------------------------
+# Happy path — TOOL-REQ-022's transport half
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_single_frame_send_reaches_a_stock_isotp_peer(vcan_channel):
+    """A payload small enough for one ISO-TP frame (<=7 bytes on classic
+    CAN), sent through our transport, arrives byte-identical at a peer using
+    isotp.CanStack directly — the oracle for the send direction.
+    """
+
+
+@SKIP
+def test_multi_frame_send_reaches_a_stock_isotp_peer(vcan_channel):
+    """A payload beyond one frame, sent through our transport, triggers the
+    First-Frame/Flow-Control/Consecutive-Frame handshake and arrives
+    byte-identical at a stock isotp.CanStack peer — proves our HAL bridge
+    doesn't break segmentation.
+    """
+
+
+@SKIP
+def test_single_frame_received_from_a_stock_isotp_peer(vcan_channel):
+    """Reverse direction: a stock isotp.CanStack peer sends a single-frame
+    payload; our transport reassembles (trivially, for one frame) and
+    returns it byte-identical.
+    """
+
+
+@SKIP
+def test_multi_frame_received_from_a_stock_isotp_peer(vcan_channel):
+    """Reverse direction, multi-frame: a stock isotp.CanStack peer sends a
+    payload requiring segmentation; our transport correctly handles flow
+    control and reassembles it byte-identical to what was sent.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_payload_exactly_at_single_frame_boundary(vcan_channel):
+    """Exactly 7 bytes (classic CAN's single-frame max with a 1-byte PCI)
+    round-trips as a single frame, not an unnecessary multi-frame sequence.
+    """
+
+
+@SKIP
+def test_payload_one_byte_over_single_frame_boundary_triggers_segmentation(vcan_channel):
+    """8 bytes — one byte past the single-frame boundary — correctly
+    triggers multi-frame segmentation rather than truncating or erroring.
+    """
+
+
+@SKIP
+def test_large_payload_near_classic_isotp_maximum_round_trips(vcan_channel):
+    """A payload approaching classic ISO-TP's 4095-byte maximum round-trips
+    correctly — proves flow-control block-size/separation-time handling
+    works across many consecutive frames, not just two or three.
+    """
+
+
+@SKIP
+def test_configurable_arbitration_ids_are_not_hardcoded(vcan_channel):
+    """A transport opened with a non-default rx/tx ID pair works correctly
+    — arbitration IDs are a construction-time config, matching HAL's own
+    "swap is a config change" property (TOOL-REQ-001) carried up to L2.
+    """
+
+
+@SKIP
+def test_recv_times_out_cleanly_with_no_traffic(vcan_channel):
+    """Derived from NFR-003 (test determinism), same boundary HAL-01/02
+    already established for its own recv(): no traffic means a prompt
+    timeout, not a hang.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_out_of_sequence_consecutive_frame_is_reported_not_silently_misassembled(vcan_channel):
+    """A peer sending Consecutive Frames with a wrong sequence number is a
+    malformed transfer. Our transport must surface this as an error (or a
+    dropped/None result with the error visible via a callback/log) rather
+    than silently assembling a wrong payload — the "silently wrong decode"
+    failure mode the whole verification ladder exists to catch (plan §3).
+    """
+
+
+@SKIP
+def test_send_after_close_raises_clear_error(vcan_channel):
+    """Using a transport handle after close() raises a clear, typed error —
+    matching the HalError convention HAL-01 already established, not a bare
+    exception surfaced from deep inside can-isotp.
+    """
+
+
+@SKIP
+def test_underlying_hal_bus_closed_does_not_hang_recv(vcan_channel):
+    """If the tapwright.hal.Bus underneath is closed while a recv() is
+    in-flight (e.g. another thread calls bus.shutdown()), recv() returns or
+    raises promptly rather than blocking forever — a hang here would be a
+    much worse test-suite failure mode than a clean error, since it doesn't
+    even produce a readable pytest failure, just a stuck CI job.
+    """


### PR DESCRIPTION
## What this changes and why

Refs #11. DIAG-01 — the ISO-TP transport DIAG-02 (the UDS client) will sit on top of, next on the plan's critical path (§6.1: `HAL-02 → DIAG-01 → DIAG-02`) now that HAL-01/HAL-02 (#3, merged) give it a real `Bus` to build on.

`tapwright.diag.isotp_transport.IsoTpTransport` wraps `can-isotp`'s `isotp.TransportLayer` via `rxfn`/`txfn` adapters bridging `hal.Frame` <-> `isotp.CanMessage` — built on `hal.Bus`, not a raw `python-can` bus, per the layering decided on #11 (`tools/virtual_ecu` took that shortcut before HAL existed; flagged there as a known inconsistency, out of this PR's scope).

Full test plan, oracle, and scope notes on #11.

## Type of change
- [x] New feature

## Checklist
- [x] DCO sign-off
- [x] Tests added — 12 T3 differential cases, every one against a stock `isotp.CanStack` peer (the oracle), both directions, boundary sizes, configurable IDs, two error paths
- [x] `CHANGELOG.md` — will update once CI confirms the implementation is correct, to avoid documenting something not yet proven
- [x] `ruff check`, `ruff format --check`, `mypy` clean; all 4 guardrail scripts clean

## How this was tested
Locally: full gate clean, all 12 new cases skip correctly (no `vcan` on this Windows dev machine) rather than erroring on import. **This PR's own CI is the actual verification** — same pattern as INF-05 and HAL-01/02: `vcan`-gated differential tests can only be proven red→green on a real Linux runner.