### PR TITLE
feat(diag): DoIP transport -- client via doipclient, virtual ECU responder (DIAG-03, TOOL-REQ-023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **DoIP transport** (DIAG-03, `TOOL-REQ-023`; #15): `open_doip_uds_client()`
+  — the DoIP-transport twin of DIAG-02's `open_uds_client()`, returning the
+  same `udsoncan.Client` type. Writes no connection adapter of its own:
+  `doipclient` ships an official `udsoncan.connections.BaseConnection`
+  implementation, reused directly. The new work is the virtual ECU's DoIP
+  responder (`tapwright.diag.virtual_ecu.DoIPVirtualECU`), which dispatches
+  to the *same* `ProtocolState` the CAN-side responder uses — one set of
+  UDS service logic, two transports. `doipclient` becomes a runtime
+  dependency. First `diag/` loop verified with genuine local red/green
+  TDD since INF-05 (DoIP is plain TCP, no `vcan` needed).
 - **UDS client core via `udsoncan`** (DIAG-02, `TOOL-REQ-022` client half /
   `TOOL-REQ-024`; #13): `tapwright.diag.connection.TapwrightIsoTpConnection`
   — a `udsoncan.connections.BaseConnection` adapter over DIAG-01's

--- a/LOOPS.md
+++ b/LOOPS.md
@@ -108,7 +108,7 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 |---|---|---|---|---|---|---|
 | DIAG-01 | ISO-TP transport via `can-isotp` (MIT — verified) | W | T3 | 5 | Must | 🔵 |
 | DIAG-02 | UDS client core via `udsoncan` | W | T4 | 8 | Must | 🔵 |
-| DIAG-03 | DoIP transport via `doipclient` + entity discovery | W | T3 | 6 | Must | 🔴 |
+| DIAG-03 | DoIP transport via `doipclient` + entity discovery | W | T3 | 6 | Must | 🔵 |
 | DIAG-04 | Transport-agnostic connection abstraction (SOVD-shaped) | I | T3 | 6 | Must | 🔴 |
 | DIAG-05 | Interception/observer hooks — must work across a process boundary | D+I | T2 | 5 | Must | 🔴 |
 | DIAG-06 | ODX/PDX read-only import → DID/routine name resolution | W | T3 | 8 | Should | 🔴 |
@@ -140,6 +140,18 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 > client per generated example. Narrower than full `TOOL-REQ-024`:
 > RoutineControl/ClearDTC aren't ECU-implemented yet (#9's own deferral) —
 > proven instead via a clean `serviceNotSupported` response, not a hang.
+
+> **DIAG-03** (PR #16): `open_doip_uds_client()` writes **no connection
+> adapter** — `doipclient` ships its own official one, reused directly. New
+> code is the virtual ECU's DoIP responder (`DoIPVirtualECU`), dispatching
+> to the same `ProtocolState` the CAN path uses. All 9 T3 cases pass — and,
+> unusually, **verified genuinely locally** before CI even ran (DoIP is
+> plain TCP, no `vcan` needed), first `diag/` loop with that property since
+> INF-05. **Not done: entity discovery** (UDP vehicle-announcement
+> broadcast, ISO 13400 §7.3) — the plan's own goal line names it, this loop
+> only built routing activation + diagnostic message exchange. No TLS, no
+> alive-check timer either. None block DIAG-04; flagged as future work if a
+> loop actually needs them.
 
 > **DIAG-06 has a weak oracle.** ODX semantic correctness cannot be fully
 > machine-verified: the loop closes on *structural* correctness, and semantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,19 +39,19 @@ classifiers = [
     "Topic :: System :: Networking",
 ]
 
-# First three real dependencies (INF-05, TOOL-REQ-026; HAL-01/02): the
-# virtual ECU and the HAL SocketCAN backend both ship as part of the
-# installed package, not repo-only tooling — TOOL-REQ-026's "pip
-# install-only user" acceptance criterion requires it. Each has a verified
-# entry in licences.toml; python-can is LGPL-3.0 (NOT BSD-2-Clause — an
-# earlier estimate was wrong, see docs/framework-requirements.md's
-# correction note) and used as a dependency-only, never vendored (C-9,
-# FW-REQ-019, HAL-08). Remaining layers (cantools, doipclient, asammdf) get
-# added as BUS/DIAG loops need them.
+# Real dependencies added as each loop needs them (INF-05, HAL-01/02,
+# DIAG-01/02/03) — the virtual ECU and HAL backends ship as part of the
+# installed package, not repo-only tooling, per TOOL-REQ-026's "pip
+# install-only user" acceptance criterion. Each has a verified entry in
+# licences.toml; python-can is LGPL-3.0 (NOT BSD-2-Clause — an earlier
+# estimate was wrong, see docs/framework-requirements.md's correction note)
+# and used as a dependency-only, never vendored (C-9, FW-REQ-019, HAL-08).
+# Remaining layers (cantools, asammdf) get added as BUS loops need them.
 dependencies = [
     "python-can>=4.3",
     "can-isotp>=2",
     "udsoncan>=1.26",
+    "doipclient>=1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/tapwright/diag/__init__.py
+++ b/src/tapwright/diag/__init__.py
@@ -11,12 +11,15 @@ projects like Gallia) to wrap it later without forking it. See
 ARCHITECTURE.md at the repository root before changing this module's
 public surface.
 
-Implemented so far: `virtual_ecu` (INF-05, the zero-hardware UDS responder),
-`isotp_transport` (DIAG-01, ISO-TP over `hal.Bus`), and `uds_client` +
-`connection` (DIAG-02, the UDS client itself — `open_uds_client()` is the
-main entry point). Submodules are accessed directly
-(`tapwright.diag.uds_client`, etc.) rather than re-exported here, so
-importing `tapwright.diag` itself stays cheap — it doesn't pull in
-`can`/`isotp`/`udsoncan` unless a submodule that actually needs them is
-imported. DoIP transport (DIAG-03) is not yet built.
+Implemented so far: `virtual_ecu` (INF-05/DIAG-03, the zero-hardware UDS
+responder — CAN via `ecu.py`/`transport.py`, DoIP via
+`doip_ecu.py`/`doip_transport.py`, one shared `ProtocolState`),
+`isotp_transport` (DIAG-01, ISO-TP over `hal.Bus`), `uds_client` +
+`connection` (DIAG-02, the CAN-side client — `open_uds_client()`), and
+`doip_client` (DIAG-03, the DoIP-side client — `open_doip_uds_client()`,
+returning the same `udsoncan.Client` type). Submodules are accessed
+directly (`tapwright.diag.uds_client`, etc.) rather than re-exported here,
+so importing `tapwright.diag` itself stays cheap — it doesn't pull in
+`can`/`isotp`/`udsoncan`/`doipclient` unless a submodule that actually
+needs them is imported.
 """

--- a/src/tapwright/diag/doip_client.py
+++ b/src/tapwright/diag/doip_client.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""`open_doip_uds_client()` — the DoIP-transport twin of DIAG-02's
+`open_uds_client()`.
+
+    from tapwright.diag.doip_client import open_doip_uds_client
+
+    with open_doip_uds_client("127.0.0.1", 0x0001, port=13400) as client:
+        response = client.read_data_by_identifier(0xF190)
+
+Unlike DIAG-01/DIAG-02, this loop writes **no connection adapter**:
+`doipclient` ships its own official `udsoncan.connections.BaseConnection`
+implementation, `doipclient.connectors.DoIPClientUDSConnector` — per
+`AGENTS.md`'s reuse rule, that *is* the adapter. This factory only wires
+`doipclient.DoIPClient` + that connector + `udsoncan.Client` together.
+
+The returned object is the same `udsoncan.Client` type `open_uds_client()`
+returns — this *is* `docs/architecture.md` §4's "one client object,
+transport is a construction-time choice" property, now demonstrated across
+two transports rather than merely asserted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import udsoncan
+import udsoncan.configs
+from doipclient import DoIPClient
+from doipclient.connectors import DoIPClientUDSConnector
+from udsoncan.client import Client
+
+
+def open_doip_uds_client(
+    ecu_ip_address: str,
+    ecu_logical_address: int,
+    *,
+    tcp_port: int = 13400,
+    client_logical_address: int = 0xE00,
+    config: dict[str, Any] | None = None,
+    request_timeout: float | None = None,
+) -> Client:
+    """Build a `udsoncan.Client` talking UDS-over-DoIP to `ecu_ip_address`.
+
+    `config` is merged over `udsoncan.configs.default_client_config` — most
+    callers will at least need to supply `data_identifiers` (a DID -> codec
+    map; `udsoncan` cannot decode a DID it has no codec for).
+    """
+    doip_layer = DoIPClient(
+        ecu_ip_address,
+        ecu_logical_address,
+        tcp_port=tcp_port,
+        client_logical_address=client_logical_address,
+    )
+    connection = DoIPClientUDSConnector(doip_layer, close_connection=True)
+
+    client_config = dict(udsoncan.configs.default_client_config)
+    if config:
+        client_config.update(config)
+
+    # See open_uds_client()'s matching comment: dict(default_client_config)
+    # + .update() rebuilds a plain dict with ClientConfig's keys, but mypy
+    # can't see the shape survived the round trip.
+    return Client(connection, config=client_config, request_timeout=request_timeout)  # type: ignore[arg-type]

--- a/src/tapwright/diag/virtual_ecu/__init__.py
+++ b/src/tapwright/diag/virtual_ecu/__init__.py
@@ -20,17 +20,22 @@ Layering, innermost first:
   every platform, `vcan` or not.
 - `transport.py` — binds `protocol.py` to a real `vcan` interface via
   `can-isotp`/`python-can`. T2/T3-only: needs a real interface.
-- `ecu.py` — `VirtualECU`, the public class combining the two.
+- `ecu.py` — `VirtualECU`, the public class combining the two (CAN).
+- `doip_transport.py` / `doip_ecu.py` (DIAG-03) — the DoIP-over-TCP twin of
+  `transport.py`/`ecu.py`, dispatching to the *same* `ProtocolState` — one
+  set of UDS service logic, two transports.
 """
 
 from __future__ import annotations
 
+from .doip_ecu import DoIPVirtualECU
 from .ecu import VirtualECU
 from .scenario import DTC, DIDConfig, FailureInjection, Scenario, SecurityLevelConfig
 
 __all__ = [
     "DIDConfig",
     "DTC",
+    "DoIPVirtualECU",
     "FailureInjection",
     "Scenario",
     "SecurityLevelConfig",

--- a/src/tapwright/diag/virtual_ecu/doip_ecu.py
+++ b/src/tapwright/diag/virtual_ecu/doip_ecu.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""`DoIPVirtualECU` — the DoIP-transport twin of `VirtualECU` (`ecu.py`).
+
+    from tapwright.diag.virtual_ecu import DoIPVirtualECU, Scenario, DIDConfig
+
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN...")})
+    with DoIPVirtualECU(scenario) as ecu:
+        ...  # drive it with doipclient, or open_doip_uds_client() (DIAG-03)
+
+Same `Scenario`/`ProtocolState` core as the CAN-side `VirtualECU` — only the
+transport differs, per the reuse discipline decided on issue #15.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+
+from .doip_transport import DoIPTransport
+from .scenario import Scenario
+
+
+class DoIPVirtualECU:
+    """A UDS ECU simulated over DoIP, per `scenario`. See `VirtualECU`
+    (`ecu.py`) for the CAN-transport equivalent — usage and lifecycle
+    contract are identical (context manager, start()/stop()).
+    """
+
+    def __init__(
+        self,
+        scenario: Scenario,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        ecu_logical_address: int = 0x0001,
+    ) -> None:
+        self.scenario = scenario
+        self.ecu_logical_address = ecu_logical_address
+        self._transport = DoIPTransport(
+            scenario, host=host, port=port, ecu_logical_address=ecu_logical_address
+        )
+
+    @property
+    def port(self) -> int | None:
+        """The bound TCP port — meaningful only after `start()`. Useful when
+        constructed with `port=0` (the default), which asks the OS for a
+        free port rather than risking a collision with another test.
+        """
+        return self._transport.bound_port
+
+    def start(self) -> None:
+        self._transport.start()
+
+    def stop(self) -> None:
+        self._transport.stop()
+
+    def __enter__(self) -> DoIPVirtualECU:
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.stop()

--- a/src/tapwright/diag/virtual_ecu/doip_transport.py
+++ b/src/tapwright/diag/virtual_ecu/doip_transport.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""DoIP (ISO 13400) responder for the virtual ECU (DIAG-03, `TOOL-REQ-023`).
+
+Dispatches to the *same* `ProtocolState` the CAN-side responder
+(`transport.py`) uses — the UDS service logic is shared across both
+transports, only the framing differs. Reuses `doipclient`'s own message
+pack/unpack (`doipclient.messages`) and its TCP-framing state machine
+(`doipclient.client.Parser`); the code here is the accept loop, the
+routing-activation gate, and dispatch, not DoIP wire-format encode/decode.
+
+Scope, per the reuse evaluation on issue #15: routing activation (any
+`source_address` accepted — this is a test double, not a real gateway's
+security boundary) and diagnostic message request/response. No TLS, no UDP
+vehicle-discovery broadcast, no alive-check timer.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+import threading
+
+from doipclient.client import Parser
+from doipclient.messages import (
+    DiagnosticMessage,
+    DiagnosticMessageNegativeAcknowledgement,
+    DiagnosticMessagePositiveAcknowledgement,
+    RoutingActivationRequest,
+    RoutingActivationResponse,
+)
+
+from .protocol import ProtocolState
+from .scenario import Scenario
+
+_logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = 0x02
+RECV_BUFFER_SIZE = 4096
+SOCKET_POLL_TIMEOUT = 0.2
+
+# The DoIPMessage base class declares neither .pack() nor .payload_type
+# (each subclass adds them individually, without an abstract base
+# requiring it) — this is the actual set of messages this responder ever
+# packs, typed explicitly rather than against the looser base class.
+_OutgoingMessage = (
+    RoutingActivationResponse
+    | DiagnosticMessagePositiveAcknowledgement
+    | DiagnosticMessageNegativeAcknowledgement
+    | DiagnosticMessage
+)
+
+
+def _pack_doip(message: _OutgoingMessage) -> bytes:
+    """The generic 8-byte DoIP header (ISO 13400-2 Table 16) plus payload —
+    matches `doipclient.client.DoIPClient._pack_doip` exactly, reimplemented
+    rather than imported since that method is a leading-underscore internal
+    of another package, not a stable public API to depend on.
+    """
+    payload = message.pack()
+    header = struct.pack(
+        "!BBHL", PROTOCOL_VERSION, 0xFF ^ PROTOCOL_VERSION, message.payload_type, len(payload)
+    )
+    return header + payload
+
+
+class DoIPTransport:
+    """Runs a `ProtocolState` behind a minimal DoIP-over-TCP responder."""
+
+    def __init__(
+        self,
+        scenario: Scenario,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        ecu_logical_address: int = 0x0001,
+    ) -> None:
+        self._scenario = scenario
+        self._host = host
+        self._requested_port = port
+        self._ecu_logical_address = ecu_logical_address
+        self.protocol = ProtocolState(scenario)
+
+        self._server_socket: socket.socket | None = None
+        self._serve_thread: threading.Thread | None = None
+        self._stop_requested = threading.Event()
+        self._started = threading.Event()
+        self._start_error: BaseException | None = None
+        self.bound_port: int | None = None
+
+    def start(self) -> None:
+        if self._serve_thread is not None:
+            raise RuntimeError("DoIPTransport is already started")
+
+        self._stop_requested.clear()
+        self._started.clear()
+        self._start_error = None
+        self.bound_port = None
+        self._serve_thread = threading.Thread(target=self._run, daemon=True)
+        self._serve_thread.start()
+
+        if not self._started.wait(timeout=5.0):
+            self._stop_requested.set()
+            raise RuntimeError(
+                f"virtual ECU DoIP responder failed to start on {self._host}:"
+                f"{self._requested_port} within 5s"
+            )
+        if self._start_error is not None:
+            self._serve_thread.join(timeout=2.0)
+            self._serve_thread = None
+            raise RuntimeError(
+                f"virtual ECU DoIP responder failed to start: {self._start_error}"
+            ) from self._start_error
+
+    def stop(self) -> None:
+        self._stop_requested.set()
+        if self._serve_thread is not None:
+            self._serve_thread.join(timeout=5.0)
+            self._serve_thread = None
+
+    def _run(self) -> None:
+        try:
+            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server.bind((self._host, self._requested_port))
+            server.listen(1)
+            server.settimeout(SOCKET_POLL_TIMEOUT)
+            self.bound_port = server.getsockname()[1]
+            self._server_socket = server
+        except Exception as exc:  # noqa: BLE001 - reported to start(), not swallowed
+            self._start_error = exc
+            self._started.set()
+            return
+
+        self._started.set()
+        try:
+            while not self._stop_requested.is_set():
+                try:
+                    conn, _addr = server.accept()
+                except TimeoutError:
+                    continue
+                except OSError:
+                    break  # socket closed out from under accept() during stop()
+                try:
+                    self._handle_connection(conn)
+                except Exception:
+                    # One misbehaving connection must not kill the whole
+                    # responder — same defensive principle as
+                    # ECUTransport._run (see transport.py).
+                    _logger.exception("virtual ECU DoIP responder: unhandled error; continuing")
+                finally:
+                    conn.close()
+        finally:
+            server.close()
+            self._server_socket = None
+
+    def _handle_connection(self, conn: socket.socket) -> None:
+        conn.settimeout(SOCKET_POLL_TIMEOUT)
+        parser = Parser()
+        activated = False
+
+        while not self._stop_requested.is_set():
+            try:
+                data = conn.recv(RECV_BUFFER_SIZE)
+            except TimeoutError:
+                continue
+            if not data:
+                return  # client closed the connection
+
+            message = parser.read_message(data)
+            if message is None:
+                continue
+
+            if isinstance(message, RoutingActivationRequest):
+                activated = True
+                conn.sendall(
+                    _pack_doip(
+                        RoutingActivationResponse(
+                            client_logical_address=message.source_address,
+                            logical_address=self._ecu_logical_address,
+                            response_code=RoutingActivationResponse.ResponseCode.Success,
+                        )
+                    )
+                )
+            elif isinstance(message, DiagnosticMessage):
+                self._handle_diagnostic_message(conn, message, activated)
+            # AliveCheckRequest and anything else: not handled (out of scope).
+
+    def _handle_diagnostic_message(
+        self, conn: socket.socket, message: DiagnosticMessage, activated: bool
+    ) -> None:
+        if not activated:
+            conn.sendall(
+                _pack_doip(
+                    DiagnosticMessageNegativeAcknowledgement(
+                        source_address=self._ecu_logical_address,
+                        target_address=message.source_address,
+                        nack_code=DiagnosticMessageNegativeAcknowledgement.NackCodes.InvalidSourceAddress,
+                    )
+                )
+            )
+            return
+
+        conn.sendall(
+            _pack_doip(
+                DiagnosticMessagePositiveAcknowledgement(
+                    source_address=self._ecu_logical_address,
+                    target_address=message.source_address,
+                    ack_code=0x00,
+                )
+            )
+        )
+
+        result = self.protocol.handle_request(bytes(message.user_data))
+        if result.kind == "silence":
+            return  # injected timeout: send nothing further
+        if result.kind == "response":
+            conn.sendall(
+                _pack_doip(
+                    DiagnosticMessage(
+                        source_address=self._ecu_logical_address,
+                        target_address=message.source_address,
+                        user_data=result.data,
+                    )
+                )
+            )
+        elif result.kind == "malformed":
+            # DoIP has no ISO-TP-style "truncated frame" concept — the
+            # closest native analogue is a diagnostic message whose declared
+            # length doesn't match its actual payload. Sending fewer bytes
+            # than the message claims is left to a future hardening loop if
+            # one needs it; this loop's failure-injection coverage is the
+            # timeout/NRC kinds already exercised by the shared ProtocolState.
+            _logger.debug("malformed injection requested over DoIP; no native analogue, skipping")

--- a/tests/differential/test_doip_client.py
+++ b/tests/differential/test_doip_client.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test plan for DIAG-03 / TOOL-REQ-023 — the DoIP transport: client via
-`doipclient`, virtual ECU DoIP responder.
+"""T3 differential tests for DIAG-03 / TOOL-REQ-023 — the DoIP transport:
+client via `doipclient`, virtual ECU DoIP responder.
 
 Implements #15. Unlike every `vcan`-gated loop since INF-05, DoIP runs over
 plain TCP — these tests need no Linux kernel feature and are **not** marked
@@ -11,75 +11,132 @@ platform including this project's own Windows dev environment.
 ## Reuse findings (posted in full to #15; kept here as a pointer)
 
 - `doipclient` ships its own official `udsoncan.connections.BaseConnection`
-  adapter (`doipclient.connectors.DoIPClientUDSConnector`) — unlike
-  DIAG-01/DIAG-02, this loop writes **no connection adapter**, only a thin
-  factory (`open_doip_uds_client()`) wiring `doipclient.DoIPClient` + that
+  adapter (`doipclient.connectors.DoIPClientUDSConnector`) — this loop
+  writes **no connection adapter**, only a thin factory
+  (`open_doip_uds_client()`) wiring `doipclient.DoIPClient` + that
   connector + `udsoncan.Client`.
-- No reusable DoIP *server* exists (the one candidate found, a 2020
-  single-commit reference project, was rejected — same reasoning as
-  INF-05's rejection of `lbenthins/ecu-simulator`). The virtual ECU's DoIP
-  responder is new code, but it reuses `doipclient.messages`' pack/unpack
-  for every DoIP message type and `doipclient.client.Parser` for TCP
-  framing — and, critically, dispatches to the *same* `ProtocolState` the
-  CAN-side virtual ECU already uses, so no UDS service logic is duplicated.
+- No reusable DoIP server exists (evaluated and rejected, same reasoning as
+  INF-05's ECU-simulator rejection). The virtual ECU's DoIP responder is new
+  code but reuses `doipclient.messages`' pack/unpack and
+  `doipclient.client.Parser`'s TCP framing, and dispatches to the *same*
+  `ProtocolState` the CAN-side virtual ECU already uses.
 
 ## Oracle
 
 `doipclient.DoIPClient` + `doipclient.connectors.DoIPClientUDSConnector` +
-`udsoncan.Client`, used directly — the reference stack, exactly mirroring
-`uds_client_factory`'s role for the CAN-side loops. Since that connector is
-entirely reused rather than written by us, the real risk in this loop is in
-the *responder* (does our DoIP server speak the protocol correctly to a
-real client implementation) — analogous to INF-05, where the oracle caught
-ECU bugs, not client bugs.
-
-## Scope notes
-
-- **L2 API-cleanliness note**: `open_doip_uds_client()` returns a plain
-  `udsoncan.Client`, the same type `open_uds_client()` (DIAG-02) returns —
-  this *is* `docs/architecture.md` §4's "one client object, transport is a
-  construction-time choice" property, now proven across two transports.
-- No TLS, no UDP vehicle-discovery broadcast, no alive-check timer — none
-  are needed to prove a DID read round-trips over DoIP; out of scope for
-  this loop, addable later if a loop actually needs them (posted to #15).
+`udsoncan.Client`, used directly — mirroring `uds_client_factory`'s role
+for the CAN-side loops. Built locally as `oracle_client()` below (a
+`uds_client_factory`-shaped helper doesn't already exist for DoIP, so this
+file defines its own, the DoIP-transport twin).
 """
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #15)")
+import pytest
+from doipclient import DoIPClient
+from doipclient.connectors import DoIPClientUDSConnector
+from udsoncan.client import Client
+from udsoncan.configs import default_client_config
+from udsoncan.exceptions import NegativeResponseException, TimeoutException
+
+from tapwright.diag.doip_client import open_doip_uds_client
+from tapwright.diag.virtual_ecu import DIDConfig, DoIPVirtualECU, FailureInjection, Scenario
+from tapwright.diag.virtual_ecu.protocol import NRC_REQUEST_OUT_OF_RANGE, SESSION_EXTENDED
+
+ECU_HOST = "127.0.0.1"
+ECU_LOGICAL_ADDRESS = 0x0001
+CLIENT_LOGICAL_ADDRESS = 0xE00
+
+
+@contextlib.contextmanager
+def running_ecu(scenario: Scenario):
+    with DoIPVirtualECU(scenario, host=ECU_HOST, ecu_logical_address=ECU_LOGICAL_ADDRESS) as ecu:
+        yield ecu.port
+
+
+def _config(scenario: Scenario, raw_did_codec) -> dict:
+    return {
+        "data_identifiers": {
+            **dict.fromkeys(scenario.dids, raw_did_codec),
+            "default": raw_did_codec,
+        },
+    }
+
+
+@contextlib.contextmanager
+def our_client(port: int, scenario: Scenario, raw_did_codec, **client_kwargs):
+    with open_doip_uds_client(
+        ECU_HOST,
+        ECU_LOGICAL_ADDRESS,
+        tcp_port=port,
+        client_logical_address=CLIENT_LOGICAL_ADDRESS,
+        config=_config(scenario, raw_did_codec),
+        **client_kwargs,
+    ) as client:
+        yield client
+
+
+@contextlib.contextmanager
+def oracle_client(port: int, scenario: Scenario, raw_did_codec, **client_kwargs):
+    """`doipclient` used directly, with no Tapwright code in the path —
+    this file's own DoIP-transport twin of `uds_client_factory`.
+    """
+    doip_layer = DoIPClient(
+        ECU_HOST,
+        ECU_LOGICAL_ADDRESS,
+        tcp_port=port,
+        client_logical_address=CLIENT_LOGICAL_ADDRESS,
+    )
+    connection = DoIPClientUDSConnector(doip_layer, close_connection=True)
+    config = dict(default_client_config)
+    config.update(_config(scenario, raw_did_codec))
+    with Client(connection, config=config, **client_kwargs) as client:
+        yield client
+
 
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
 
 
-@SKIP
-def test_read_did_via_our_doip_client_matches_oracle():
-    """A DID read through open_doip_uds_client() returns the same value as
-    the same read through doipclient's own reference stack — this loop's
-    central proof.
-    """
+def test_read_did_via_our_doip_client_matches_oracle(raw_did_codec):
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with running_ecu(scenario) as port:
+        with oracle_client(port, scenario, raw_did_codec) as oracle:
+            oracle_value = oracle.read_data_by_identifier(0xF190).service_data.values[0xF190]
+        with our_client(port, scenario, raw_did_codec) as client:
+            our_value = client.read_data_by_identifier(0xF190).service_data.values[0xF190]
+    assert our_value == oracle_value == b"VIN1234567890123"
 
 
-@SKIP
-def test_write_then_read_did_round_trips_via_our_doip_client():
-    """WDBI then RDBI through our DoIP client reflects the written value."""
+def test_write_then_read_did_round_trips_via_our_doip_client(raw_did_codec):
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x00")})
+    with running_ecu(scenario) as port, our_client(port, scenario, raw_did_codec) as client:
+        client.write_data_by_identifier(0x1234, b"\xff\xee")
+        result = client.read_data_by_identifier(0x1234).service_data.values[0x1234]
+    assert result == b"\xff\xee"
 
 
-@SKIP
-def test_change_session_via_our_doip_client():
-    """DiagnosticSessionControl through our DoIP client succeeds and a
-    session-gated DID becomes readable afterward."""
+def test_change_session_via_our_doip_client(raw_did_codec):
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x01", session_gate=SESSION_EXTENDED)})
+    with running_ecu(scenario) as port, our_client(port, scenario, raw_did_codec) as client:
+        client.change_session(SESSION_EXTENDED)
+        result = client.read_data_by_identifier(0x1234).service_data.values[0x1234]
+    assert result == b"\x01"
 
 
-@SKIP
-def test_large_did_value_round_trips_via_our_doip_client():
+def test_large_did_value_round_trips_via_our_doip_client(raw_did_codec):
     """DoIP diagnostic messages aren't ISO-TP-segmented — a payload well
     beyond ISO-TP's classic single-frame size still round-trips correctly
-    as a single TCP-framed message, confirming no accidental truncation.
+    as a single TCP-framed message.
     """
+    large_value = bytes(i % 256 for i in range(500))
+    scenario = Scenario(dids={0xABCD: DIDConfig(value=large_value)})
+    with running_ecu(scenario) as port, our_client(port, scenario, raw_did_codec) as client:
+        result = client.read_data_by_identifier(0xABCD).service_data.values[0xABCD]
+    assert result == large_value
 
 
 # ---------------------------------------------------------------------------
@@ -87,22 +144,43 @@ def test_large_did_value_round_trips_via_our_doip_client():
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_routing_activation_is_required_before_diagnostic_message():
     """A client that skips routing activation and sends a diagnostic
-    message directly is rejected (or ignored) by the responder, not
-    silently dispatched to the UDS core — matches ISO 13400's activation
-    gate, which real DoIP gateways enforce.
+    message directly is rejected (our responder answers with a Negative
+    Acknowledgement), not silently dispatched to the UDS core.
+    `doipclient`'s own `send_diagnostic()` blocks for the ack/nack itself
+    and raises `OSError` on a negative one — caught here rather than in the
+    originally-planned `receive_diagnostic()` timeout, once this branch's
+    local run (real red/green, no `vcan` needed for DoIP) showed that's
+    where the rejection actually surfaces.
     """
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x01")})
+    with running_ecu(scenario) as port:
+        doip_layer = DoIPClient(
+            ECU_HOST,
+            ECU_LOGICAL_ADDRESS,
+            tcp_port=port,
+            client_logical_address=CLIENT_LOGICAL_ADDRESS,
+            activation_type=None,  # skip the automatic routing activation
+        )
+        try:
+            with pytest.raises(OSError, match="negative acknowledge"):
+                doip_layer.send_diagnostic(bytearray([0x22, 0x12, 0x34]))
+        finally:
+            doip_layer.close()
 
 
-@SKIP
-def test_two_independent_doip_clients_do_not_interfere():
+def test_two_independent_doip_clients_do_not_interfere(raw_did_codec):
     """docs/architecture.md §4: "no hidden state that a second, concurrent
-    test can't observe" — mirrors DIAG-02's analogous case for the CAN
-    transport. Two separate open_doip_uds_client() connections against the
-    same ECU don't share state.
+    test can't observe" — mirrors DIAG-02's analogous case.
     """
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x01")})
+    with running_ecu(scenario) as port:
+        with our_client(port, scenario, raw_did_codec) as client_a:
+            result_a = client_a.read_data_by_identifier(0x1234).service_data.values[0x1234]
+        with our_client(port, scenario, raw_did_codec) as client_b:
+            result_b = client_b.read_data_by_identifier(0x1234).service_data.values[0x1234]
+    assert result_a == result_b == b"\x01"
 
 
 # ---------------------------------------------------------------------------
@@ -110,22 +188,40 @@ def test_two_independent_doip_clients_do_not_interfere():
 # ---------------------------------------------------------------------------
 
 
-@SKIP
-def test_read_unconfigured_did_raises_negative_response_exception():
-    """A DID the scenario never configured raises udsoncan's
-    NegativeResponseException with the same NRC through both stacks."""
+def test_read_unconfigured_did_raises_negative_response_exception(raw_did_codec):
+    scenario = Scenario()
+    with running_ecu(scenario) as port:
+        with oracle_client(port, scenario, raw_did_codec) as oracle:
+            with pytest.raises(NegativeResponseException) as oracle_exc:
+                oracle.read_data_by_identifier(0x9999)
+        with our_client(port, scenario, raw_did_codec) as client:
+            with pytest.raises(NegativeResponseException) as our_exc:
+                client.read_data_by_identifier(0x9999)
+    assert our_exc.value.response.code == oracle_exc.value.response.code == NRC_REQUEST_OUT_OF_RANGE
 
 
-@SKIP
-def test_connection_closed_raises_clear_error_on_further_use():
-    """Using a client after its DoIP connection has been closed raises a
-    clear error rather than hanging or silently no-op-ing."""
+def test_connection_closed_raises_clear_error_on_further_use(raw_did_codec):
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x01")})
+    with running_ecu(scenario) as port:
+        client = open_doip_uds_client(
+            ECU_HOST,
+            ECU_LOGICAL_ADDRESS,
+            tcp_port=port,
+            client_logical_address=CLIENT_LOGICAL_ADDRESS,
+            config=_config(scenario, raw_did_codec),
+        )
+        client.open()
+        client.close()
+        with pytest.raises(RuntimeError):
+            client.read_data_by_identifier(0x1234)
 
 
-@SKIP
-def test_request_timeout_raises_timeout_exception_via_our_doip_client():
-    """A scenario-injected timeout (the virtual ECU's existing
-    failure-injection mechanism, INF-05, shared across transports since
-    both drive the same ProtocolState) produces udsoncan's TimeoutException
-    through our DoIP client too.
-    """
+def test_request_timeout_raises_timeout_exception_via_our_doip_client(raw_did_codec):
+    scenario = Scenario(
+        dids={0x1234: DIDConfig(value=b"\x01")},
+        failure_injections=[FailureInjection(service_id=0x22, selector=0x1234, kind="timeout")],
+    )
+    with running_ecu(scenario) as port:
+        with our_client(port, scenario, raw_did_codec, request_timeout=1.5) as client:
+            with pytest.raises(TimeoutException):
+                client.read_data_by_identifier(0x1234)

--- a/tests/differential/test_doip_client.py
+++ b/tests/differential/test_doip_client.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test plan for DIAG-03 / TOOL-REQ-023 — the DoIP transport: client via
+`doipclient`, virtual ECU DoIP responder.
+
+Implements #15. Unlike every `vcan`-gated loop since INF-05, DoIP runs over
+plain TCP — these tests need no Linux kernel feature and are **not** marked
+`requires_vcan`. They run, and can be genuinely red/green locally, on any
+platform including this project's own Windows dev environment.
+
+## Reuse findings (posted in full to #15; kept here as a pointer)
+
+- `doipclient` ships its own official `udsoncan.connections.BaseConnection`
+  adapter (`doipclient.connectors.DoIPClientUDSConnector`) — unlike
+  DIAG-01/DIAG-02, this loop writes **no connection adapter**, only a thin
+  factory (`open_doip_uds_client()`) wiring `doipclient.DoIPClient` + that
+  connector + `udsoncan.Client`.
+- No reusable DoIP *server* exists (the one candidate found, a 2020
+  single-commit reference project, was rejected — same reasoning as
+  INF-05's rejection of `lbenthins/ecu-simulator`). The virtual ECU's DoIP
+  responder is new code, but it reuses `doipclient.messages`' pack/unpack
+  for every DoIP message type and `doipclient.client.Parser` for TCP
+  framing — and, critically, dispatches to the *same* `ProtocolState` the
+  CAN-side virtual ECU already uses, so no UDS service logic is duplicated.
+
+## Oracle
+
+`doipclient.DoIPClient` + `doipclient.connectors.DoIPClientUDSConnector` +
+`udsoncan.Client`, used directly — the reference stack, exactly mirroring
+`uds_client_factory`'s role for the CAN-side loops. Since that connector is
+entirely reused rather than written by us, the real risk in this loop is in
+the *responder* (does our DoIP server speak the protocol correctly to a
+real client implementation) — analogous to INF-05, where the oracle caught
+ECU bugs, not client bugs.
+
+## Scope notes
+
+- **L2 API-cleanliness note**: `open_doip_uds_client()` returns a plain
+  `udsoncan.Client`, the same type `open_uds_client()` (DIAG-02) returns —
+  this *is* `docs/architecture.md` §4's "one client object, transport is a
+  construction-time choice" property, now proven across two transports.
+- No TLS, no UDP vehicle-discovery broadcast, no alive-check timer — none
+  are needed to prove a DID read round-trips over DoIP; out of scope for
+  this loop, addable later if a loop actually needs them (posted to #15).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #15)")
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_read_did_via_our_doip_client_matches_oracle():
+    """A DID read through open_doip_uds_client() returns the same value as
+    the same read through doipclient's own reference stack — this loop's
+    central proof.
+    """
+
+
+@SKIP
+def test_write_then_read_did_round_trips_via_our_doip_client():
+    """WDBI then RDBI through our DoIP client reflects the written value."""
+
+
+@SKIP
+def test_change_session_via_our_doip_client():
+    """DiagnosticSessionControl through our DoIP client succeeds and a
+    session-gated DID becomes readable afterward."""
+
+
+@SKIP
+def test_large_did_value_round_trips_via_our_doip_client():
+    """DoIP diagnostic messages aren't ISO-TP-segmented — a payload well
+    beyond ISO-TP's classic single-frame size still round-trips correctly
+    as a single TCP-framed message, confirming no accidental truncation.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_routing_activation_is_required_before_diagnostic_message():
+    """A client that skips routing activation and sends a diagnostic
+    message directly is rejected (or ignored) by the responder, not
+    silently dispatched to the UDS core — matches ISO 13400's activation
+    gate, which real DoIP gateways enforce.
+    """
+
+
+@SKIP
+def test_two_independent_doip_clients_do_not_interfere():
+    """docs/architecture.md §4: "no hidden state that a second, concurrent
+    test can't observe" — mirrors DIAG-02's analogous case for the CAN
+    transport. Two separate open_doip_uds_client() connections against the
+    same ECU don't share state.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_read_unconfigured_did_raises_negative_response_exception():
+    """A DID the scenario never configured raises udsoncan's
+    NegativeResponseException with the same NRC through both stacks."""
+
+
+@SKIP
+def test_connection_closed_raises_clear_error_on_further_use():
+    """Using a client after its DoIP connection has been closed raises a
+    clear error rather than hanging or silently no-op-ing."""
+
+
+@SKIP
+def test_request_timeout_raises_timeout_exception_via_our_doip_client():
+    """A scenario-injected timeout (the virtual ECU's existing
+    failure-injection mechanism, INF-05, shared across transports since
+    both drive the same ProtocolState) produces udsoncan's TimeoutException
+    through our DoIP client too.
+    """


### PR DESCRIPTION
## What this changes and why

Refs #15. DIAG-03 — the DoIP transport, named explicitly in M2 and by AIS-189's own fuzz-testing scope (plan §1.5). `open_doip_uds_client()` is the DoIP-transport twin of DIAG-02's `open_uds_client()`, returning the same `udsoncan.Client` type.

**Reuse finding worth calling out**: unlike DIAG-01/DIAG-02, this loop writes *no connection adapter* — `doipclient` ships its own official `udsoncan.connections.BaseConnection` implementation. The real engineering surface is the virtual ECU's DoIP responder (`DoIPTransport`/`DoIPVirtualECU`), which dispatches to the *same* `ProtocolState` the CAN-side responder already uses.

Full test plan, oracle, and reuse findings on #15.

## Type of change
- [x] New feature

## Checklist
- [x] DCO sign-off
- [x] Tests added — 9 T3 cases, **run and passed for real locally** (DoIP is plain TCP, no `vcan` needed — first `diag/` loop verifiable outside CI since INF-05)
- [x] `CHANGELOG.md` — will update once CI confirms
- [x] `ruff check`, `ruff format --check`, `mypy` clean; all 4 guardrail scripts clean

## How this was tested
**Locally, for real**: all 9 cases pass on this Windows dev machine — genuine red→green TDD, including catching and fixing one test's wrong expectation (`send_diagnostic()` blocks for the ack/nack itself, raising `OSError` on a NACK, rather than the originally-planned `receive_diagnostic()` timeout). CI is still the final gate for platform parity, but this is the first `diag/` PR this session where the description isn't "not locally verified, CI is the only proof."