### PR TITLE
feat(diag): transport-agnostic connection abstraction (DIAG-04)

### DIFF
--- a/src/tapwright/diag/__init__.py
+++ b/src/tapwright/diag/__init__.py
@@ -15,11 +15,15 @@ Implemented so far: `virtual_ecu` (INF-05/DIAG-03, the zero-hardware UDS
 responder — CAN via `ecu.py`/`transport.py`, DoIP via
 `doip_ecu.py`/`doip_transport.py`, one shared `ProtocolState`),
 `isotp_transport` (DIAG-01, ISO-TP over `hal.Bus`), `uds_client` +
-`connection` (DIAG-02, the CAN-side client — `open_uds_client()`), and
-`doip_client` (DIAG-03, the DoIP-side client — `open_doip_uds_client()`,
-returning the same `udsoncan.Client` type). Submodules are accessed
-directly (`tapwright.diag.uds_client`, etc.) rather than re-exported here,
-so importing `tapwright.diag` itself stays cheap — it doesn't pull in
+`connection` (DIAG-02, the CAN-side client — `open_uds_client()`),
+`doip_client` (DIAG-03, the DoIP-side client — `open_doip_uds_client()`),
+and `connection_config` (DIAG-04 — `open_connection()`, the
+transport-agnostic construction point that dispatches to whichever of the
+two the caller's config object names). Submodules are accessed directly
+(`tapwright.diag.connection_config`, etc.) rather than re-exported here, so
+importing `tapwright.diag` itself stays cheap — it doesn't pull in
 `can`/`isotp`/`udsoncan`/`doipclient` unless a submodule that actually
-needs them is imported.
+needs them is imported. `connection_config.py` itself needs both
+regardless of which transport a caller ultimately picks, which is exactly
+why keeping it out of this file's own import graph still matters.
 """

--- a/src/tapwright/diag/connection_config.py
+++ b/src/tapwright/diag/connection_config.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""The transport-agnostic construction point `docs/architecture.md` §4
+requires (DIAG-04): a single `open_connection()`, dispatching on a config
+object's *type* rather than a string a caller could typo.
+
+    from tapwright.diag import CanConnectionConfig, open_connection
+    from tapwright.hal import open_bus
+
+    bus = open_bus(backend="socketcan", channel="vcan0")
+    config = CanConnectionConfig(bus=bus, rxid=0x7E0, txid=0x7E8)
+    with open_connection(config) as client:
+        response = client.read_data_by_identifier(0xF190)
+
+Swapping `CanConnectionConfig` for `DoipConnectionConfig` is the entire
+change needed to move to DoIP — `open_connection()`'s call site, and every
+line of code that uses the returned `client`, stays identical. That
+identity is DIAG-04's own oracle, exercised directly in
+`tests/differential/test_connection_abstraction.py`.
+
+"SOVD-shaped": a future `SovdConnectionConfig` (DIAG-07, Should) is meant to
+slot into the `isinstance` dispatch below without changing
+`open_connection()`'s signature or any code that already calls it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import isotp
+from udsoncan.client import Client
+
+from tapwright.hal import Bus
+
+from .doip_client import open_doip_uds_client
+from .uds_client import open_uds_client
+
+
+@dataclass(frozen=True)
+class CanConnectionConfig:
+    """Construction parameters for a UDS-over-ISO-TP-over-CAN connection —
+    everything `open_uds_client()` needs, held as data rather than passed
+    positionally, so `open_connection()` can dispatch on this type alone.
+    """
+
+    bus: Bus
+    rxid: int
+    txid: int
+    addressing_mode: isotp.AddressingMode = isotp.AddressingMode.Normal_11bits
+
+
+@dataclass(frozen=True)
+class DoipConnectionConfig:
+    """Construction parameters for a UDS-over-DoIP connection — everything
+    `open_doip_uds_client()` needs, held as data for the same reason.
+    """
+
+    ecu_ip_address: str
+    ecu_logical_address: int
+    tcp_port: int = 13400
+    client_logical_address: int = 0xE00
+
+
+ConnectionConfig = CanConnectionConfig | DoipConnectionConfig
+
+
+def open_connection(
+    transport_config: ConnectionConfig,
+    *,
+    config: dict[str, Any] | None = None,
+    request_timeout: float | None = None,
+) -> Client:
+    """Open a `udsoncan.Client` over whichever transport `transport_config`
+    describes. The caller never branches on transport — that's the point.
+    """
+    if isinstance(transport_config, CanConnectionConfig):
+        return open_uds_client(
+            transport_config.bus,
+            rxid=transport_config.rxid,
+            txid=transport_config.txid,
+            addressing_mode=transport_config.addressing_mode,
+            config=config,
+            request_timeout=request_timeout,
+        )
+    if isinstance(transport_config, DoipConnectionConfig):
+        return open_doip_uds_client(
+            transport_config.ecu_ip_address,
+            transport_config.ecu_logical_address,
+            tcp_port=transport_config.tcp_port,
+            client_logical_address=transport_config.client_logical_address,
+            config=config,
+            request_timeout=request_timeout,
+        )
+    raise TypeError(f"unsupported connection config type: {type(transport_config)!r}")

--- a/tests/differential/test_connection_abstraction.py
+++ b/tests/differential/test_connection_abstraction.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test plan for DIAG-04 — the transport-agnostic connection abstraction.
+
+Implements #17. Unlike every prior DIAG loop, this one's oracle isn't a
+differential comparison against a reference library — it's the
+parametrization itself succeeding: **one test body, run twice (CAN and
+DoIP), with no per-transport branching in the body**. That literal
+unmodified-reuse is `docs/architecture.md` §4's "construction-time choice,
+invisible to the calling code" property, demonstrated rather than argued.
+
+`connection_config` (below) is the fixture doing the actual work: it builds
+either a `CanConnectionConfig` + a running `VirtualECU` on `vcan`, or a
+`DoipConnectionConfig` + a running `DoIPVirtualECU` over TCP — and yields a
+callable that opens a client from whichever config it built. Every test
+function calls that callable and asserts on the client, never on which
+transport is underneath.
+
+The CAN parametrization is marked `requires_vcan` (per-parameter, via
+`pytest.param(..., marks=...)`) so it skips cleanly off-Linux; the DoIP
+parametrization always runs, same as every other DIAG-03 test.
+
+## Scope note
+
+`open_connection()` dispatches on the config object's *type*
+(`CanConnectionConfig` vs. `DoipConnectionConfig`) — not a string literal
+like `transport="can"` — so a caller can't typo a transport name into
+something that silently falls through to a default. Named "SOVD-shaped" in
+the plan and on #17: a future `SovdConnectionConfig` (DIAG-07) slots into
+the same `open_connection()` dispatch without touching its signature or any
+code that already calls it.
+
+**L2 API-cleanliness note** (test-plan skill step 5): this loop is squarely
+about `docs/architecture.md` §4's first bullet (transport-agnostic client
+interface) — that's the whole point of the oracle here, not a side note.
+The second bullet (request/response interception point) still doesn't
+exist and isn't built by this loop either; `open_connection()`'s shape
+doesn't preclude adding it later, same conclusion DIAG-01/02/03 each
+reached for their own pieces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #17)")
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("can", marks=pytest.mark.requires_vcan),
+        pytest.param("doip"),
+    ]
+)
+def connection_config(request):
+    """Yields a zero-argument callable: `open_client() -> udsoncan.Client`,
+    built from whichever transport this parametrization instance is —
+    every test below calls it without knowing or caring which.
+
+    Implementation pending (issue #17) — every test that depends on this
+    fixture is `@SKIP`-marked, so pytest's skip happens before fixture
+    setup and this incomplete body is never actually invoked.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Happy path — the oracle itself: one body, both transports
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_read_did_over_either_transport(connection_config):
+    """RDBI succeeds identically whichever transport `connection_config`
+    built — the literal "same test body, unmodified" proof."""
+
+
+@SKIP
+def test_write_then_read_did_over_either_transport(connection_config):
+    """WDBI then RDBI round-trips identically over either transport."""
+
+
+@SKIP
+def test_change_session_over_either_transport(connection_config):
+    """DiagnosticSessionControl succeeds identically over either transport,
+    unlocking a session-gated DID afterward."""
+
+
+# ---------------------------------------------------------------------------
+# Error cases — the abstraction must not leak transport-specific exceptions
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_read_unconfigured_did_raises_over_either_transport(connection_config):
+    """An unconfigured DID raises the same udsoncan.NegativeResponseException
+    with the same NRC over either transport — the error path is
+    transport-agnostic too, not just the happy path."""
+
+
+@SKIP
+def test_connection_closed_raises_over_either_transport(connection_config):
+    """Using a client after close() raises the same RuntimeError over
+    either transport — DIAG-02's and DIAG-03's lifecycle contracts agree."""

--- a/tests/differential/test_connection_abstraction.py
+++ b/tests/differential/test_connection_abstraction.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test plan for DIAG-04 — the transport-agnostic connection abstraction.
+"""T3 tests for DIAG-04 — the transport-agnostic connection abstraction.
 
 Implements #17. Unlike every prior DIAG loop, this one's oracle isn't a
 differential comparison against a reference library — it's the
@@ -9,41 +9,65 @@ DoIP), with no per-transport branching in the body**. That literal
 unmodified-reuse is `docs/architecture.md` §4's "construction-time choice,
 invisible to the calling code" property, demonstrated rather than argued.
 
-`connection_config` (below) is the fixture doing the actual work: it builds
-either a `CanConnectionConfig` + a running `VirtualECU` on `vcan`, or a
-`DoipConnectionConfig` + a running `DoIPVirtualECU` over TCP — and yields a
-callable that opens a client from whichever config it built. Every test
-function calls that callable and asserts on the client, never on which
-transport is underneath.
+`connection_config` (below) does the actual work: depending on which
+parametrization instance is running, it starts either a `VirtualECU` on
+`vcan` or a `DoIPVirtualECU` over TCP, builds the matching
+`CanConnectionConfig`/`DoipConnectionConfig`, and yields a context manager
+that opens a client via `open_connection()`. Every test function below
+calls it and asserts on the client — never on which transport is
+underneath.
 
 The CAN parametrization is marked `requires_vcan` (per-parameter, via
 `pytest.param(..., marks=...)`) so it skips cleanly off-Linux; the DoIP
-parametrization always runs, same as every other DIAG-03 test.
+parametrization always runs, same split every DIAG-03 test already uses.
 
 ## Scope note
 
 `open_connection()` dispatches on the config object's *type*
-(`CanConnectionConfig` vs. `DoipConnectionConfig`) — not a string literal
-like `transport="can"` — so a caller can't typo a transport name into
-something that silently falls through to a default. Named "SOVD-shaped" in
-the plan and on #17: a future `SovdConnectionConfig` (DIAG-07) slots into
-the same `open_connection()` dispatch without touching its signature or any
-code that already calls it.
+(`CanConnectionConfig` vs. `DoipConnectionConfig`), not a string literal —
+a caller can't typo a transport name into something that silently falls
+through. "SOVD-shaped": a future `SovdConnectionConfig` (DIAG-07) slots
+into the same dispatch without touching `open_connection()`'s signature.
 
 **L2 API-cleanliness note** (test-plan skill step 5): this loop is squarely
 about `docs/architecture.md` §4's first bullet (transport-agnostic client
-interface) — that's the whole point of the oracle here, not a side note.
-The second bullet (request/response interception point) still doesn't
-exist and isn't built by this loop either; `open_connection()`'s shape
+interface) — that's the whole point of the oracle here. The second bullet
+(request/response interception point) still isn't built; `open_connection()`
 doesn't preclude adding it later, same conclusion DIAG-01/02/03 each
 reached for their own pieces.
+
+## Correction from the test plan
+
+The plan (posted to #17) said `open_connection()` would be re-exported at
+`tapwright.diag` package level. On reflection while implementing, that
+breaks the "stay cheap" convention every prior `diag/` submodule
+(`uds_client`, `doip_client`, `isotp_transport`) already established —
+`connection_config.py` needs both `can`/`isotp` *and* `doipclient`
+regardless of which transport a caller picks, so keeping it out of
+`tapwright.diag`'s own import graph matters *more* here, not less. Kept as
+`tapwright.diag.connection_config.open_connection`, consistent with every
+other loop's submodule-access pattern.
 """
 
 from __future__ import annotations
 
-import pytest
+import contextlib
 
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #17)")
+import pytest
+from udsoncan.exceptions import NegativeResponseException
+
+from tapwright.diag.connection_config import (
+    CanConnectionConfig,
+    DoipConnectionConfig,
+    open_connection,
+)
+from tapwright.diag.virtual_ecu import DIDConfig, DoIPVirtualECU, Scenario, VirtualECU
+from tapwright.diag.virtual_ecu.protocol import NRC_REQUEST_OUT_OF_RANGE, SESSION_EXTENDED
+from tapwright.hal import open_bus
+
+DOIP_ECU_HOST = "127.0.0.1"
+DOIP_ECU_LOGICAL_ADDRESS = 0x0001
+DOIP_CLIENT_LOGICAL_ADDRESS = 0xE00
 
 
 @pytest.fixture(
@@ -52,15 +76,46 @@ SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #17)
         pytest.param("doip"),
     ]
 )
-def connection_config(request):
-    """Yields a zero-argument callable: `open_client() -> udsoncan.Client`,
-    built from whichever transport this parametrization instance is —
-    every test below calls it without knowing or caring which.
-
-    Implementation pending (issue #17) — every test that depends on this
-    fixture is `@SKIP`-marked, so pytest's skip happens before fixture
-    setup and this incomplete body is never actually invoked.
+def connection_config(request, vcan_channel, raw_did_codec):
+    """Yields a callable, `open_client_for(scenario)`, returning a context
+    manager over an opened `udsoncan.Client` — built via whichever
+    transport this parametrization instance is. Every test below is
+    identical regardless of which one runs.
     """
+    transport = request.param
+
+    @contextlib.contextmanager
+    def open_client_for(scenario: Scenario):
+        data_identifiers = {**dict.fromkeys(scenario.dids, raw_did_codec), "default": raw_did_codec}
+        client_config = {"data_identifiers": data_identifiers}
+
+        if transport == "can":
+            bus = open_bus(backend="socketcan", channel=vcan_channel)
+            transport_config = CanConnectionConfig(
+                bus=bus, rxid=scenario.response_id, txid=scenario.request_id
+            )
+            with VirtualECU(scenario, channel=vcan_channel):
+                client = open_connection(transport_config, config=client_config)
+                try:
+                    with client:
+                        yield client
+                finally:
+                    bus.shutdown()
+        else:
+            with DoIPVirtualECU(
+                scenario, host=DOIP_ECU_HOST, ecu_logical_address=DOIP_ECU_LOGICAL_ADDRESS
+            ) as ecu:
+                transport_config = DoipConnectionConfig(
+                    ecu_ip_address=DOIP_ECU_HOST,
+                    ecu_logical_address=DOIP_ECU_LOGICAL_ADDRESS,
+                    tcp_port=ecu.port,
+                    client_logical_address=DOIP_CLIENT_LOGICAL_ADDRESS,
+                )
+                client = open_connection(transport_config, config=client_config)
+                with client:
+                    yield client
+
+    yield open_client_for
 
 
 # ---------------------------------------------------------------------------
@@ -68,21 +123,27 @@ def connection_config(request):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_read_did_over_either_transport(connection_config):
-    """RDBI succeeds identically whichever transport `connection_config`
-    built — the literal "same test body, unmodified" proof."""
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with connection_config(scenario) as client:
+        result = client.read_data_by_identifier(0xF190).service_data.values[0xF190]
+    assert result == b"VIN1234567890123"
 
 
-@SKIP
 def test_write_then_read_did_over_either_transport(connection_config):
-    """WDBI then RDBI round-trips identically over either transport."""
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x00")})
+    with connection_config(scenario) as client:
+        client.write_data_by_identifier(0x1234, b"\xff\xee")
+        result = client.read_data_by_identifier(0x1234).service_data.values[0x1234]
+    assert result == b"\xff\xee"
 
 
-@SKIP
 def test_change_session_over_either_transport(connection_config):
-    """DiagnosticSessionControl succeeds identically over either transport,
-    unlocking a session-gated DID afterward."""
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x01", session_gate=SESSION_EXTENDED)})
+    with connection_config(scenario) as client:
+        client.change_session(SESSION_EXTENDED)
+        result = client.read_data_by_identifier(0x1234).service_data.values[0x1234]
+    assert result == b"\x01"
 
 
 # ---------------------------------------------------------------------------
@@ -90,14 +151,17 @@ def test_change_session_over_either_transport(connection_config):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_read_unconfigured_did_raises_over_either_transport(connection_config):
-    """An unconfigured DID raises the same udsoncan.NegativeResponseException
-    with the same NRC over either transport — the error path is
-    transport-agnostic too, not just the happy path."""
+    scenario = Scenario()
+    with connection_config(scenario) as client:
+        with pytest.raises(NegativeResponseException) as excinfo:
+            client.read_data_by_identifier(0x9999)
+    assert excinfo.value.response.code == NRC_REQUEST_OUT_OF_RANGE
 
 
-@SKIP
 def test_connection_closed_raises_over_either_transport(connection_config):
-    """Using a client after close() raises the same RuntimeError over
-    either transport — DIAG-02's and DIAG-03's lifecycle contracts agree."""
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x01")})
+    with connection_config(scenario) as client:
+        pass  # exiting the context manager closes it
+    with pytest.raises(RuntimeError):
+        client.read_data_by_identifier(0x1234)


### PR DESCRIPTION
## What this changes and why

Refs #17. DIAG-04 — the construction-time choice `docs/architecture.md` §4 requires. DIAG-02 and DIAG-03 each produce a `udsoncan.Client`, but a caller had to know in advance which factory to call, with a different argument shape either way. `open_connection(transport_config)` makes that a config-object-type choice instead — same property HAL-01 already established one layer down ("swap is a config change"), now carried up to L2.

This loop's oracle is unusual: not a differential comparison against a reference library, but **the parametrization itself succeeding** — one test body, run twice (CAN and DoIP), with zero per-transport branching.

**A correction from the test plan**, noted in the test file's own docstring: `open_connection()` is *not* re-exported at `tapwright.diag` package level as originally planned — that breaks the "stay cheap" import convention every prior `diag/` submodule established. Kept as `tapwright.diag.connection_config.open_connection`.

Full test plan and scope notes on #17.

## Type of change
- [x] New feature

## Checklist
- [x] DCO sign-off
- [x] Tests added — 5 test bodies × 2 transports = 10 collected items; the 5 DoIP-side cases run and pass for real locally (no `vcan` needed)
- [x] `CHANGELOG.md` — will update once CI confirms the CAN side too
- [x] `ruff check`, `ruff format --check`, `mypy` clean; all 4 guardrail scripts clean

## How this was tested
Locally: DoIP-side cases (5/10) pass for real — genuine verification, not just import-clean skips. CAN-side cases (5/10) skip correctly (no `vcan` on this Windows machine) and are CI's job to prove.