### PR TITLE
docs(repo): sync CHANGELOG and LOOPS.md — DIAG-04 CI-verified green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **Transport-agnostic connection abstraction** (DIAG-04; #17):
+  `tapwright.diag.connection_config.open_connection()` — a single
+  construction-time choice (`CanConnectionConfig` vs. `DoipConnectionConfig`,
+  dispatched by type) between DIAG-02's and DIAG-03's client factories,
+  both returning the same `udsoncan.Client` type. Verified with one literal
+  test body run unmodified over both transports — the "invisible to the
+  calling code" property `docs/architecture.md` §4 requires, demonstrated
+  rather than argued. Shaped so a future `SovdConnectionConfig` (DIAG-07)
+  slots into the same dispatch.
 - **DoIP transport** (DIAG-03, `TOOL-REQ-023`; #15): `open_doip_uds_client()`
   — the DoIP-transport twin of DIAG-02's `open_uds_client()`, returning the
   same `udsoncan.Client` type. Writes no connection adapter of its own:

--- a/LOOPS.md
+++ b/LOOPS.md
@@ -109,7 +109,7 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 | DIAG-01 | ISO-TP transport via `can-isotp` (MIT — verified) | W | T3 | 5 | Must | 🔵 |
 | DIAG-02 | UDS client core via `udsoncan` | W | T4 | 8 | Must | 🔵 |
 | DIAG-03 | DoIP transport via `doipclient` + entity discovery | W | T3 | 6 | Must | 🔵 |
-| DIAG-04 | Transport-agnostic connection abstraction (SOVD-shaped) | I | T3 | 6 | Must | 🔴 |
+| DIAG-04 | Transport-agnostic connection abstraction (SOVD-shaped) | I | T3 | 6 | Must | 🔵 |
 | DIAG-05 | Interception/observer hooks — must work across a process boundary | D+I | T2 | 5 | Must | 🔴 |
 | DIAG-06 | ODX/PDX read-only import → DID/routine name resolution | W | T3 | 8 | Should | 🔴 |
 | DIAG-07 | SOVD client (REST/JSON, ISO 17978) | P | T3 | 8 | Should | 🔴 |
@@ -152,6 +152,19 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 > only built routing activation + diagnostic message exchange. No TLS, no
 > alive-check timer either. None block DIAG-04; flagged as future work if a
 > loop actually needs them.
+
+> **DIAG-04** (PR #18): `open_connection()` dispatches on config-object type
+> to DIAG-02/DIAG-03's factories. Oracle was unusual — not a differential
+> comparison but the parametrization itself succeeding — and it did, all 9
+> CI jobs green first try, DoIP-side cases (5/10) also verified for real
+> locally before ever reaching CI. **Corrected mid-implementation**: the
+> issue/test-plan said `open_connection()` would be re-exported at
+> `tapwright.diag` package level; kept as
+> `tapwright.diag.connection_config.open_connection` instead, since
+> re-exporting would've broken the "stay cheap" import convention every
+> prior `diag/` submodule established (see the test file's own docstring
+> for the full reasoning). M2's exit criterion — "same UDS test passes
+> unmodified over CAN and DoIP" — is now met.
 
 > **DIAG-06 has a weak oracle.** ODX semantic correctness cannot be fully
 > machine-verified: the loop closes on *structural* correctness, and semantic


### PR DESCRIPTION
## What this changes and why

This commit was already reviewed and pushed as part of #18, but PR #18 was merged on an earlier commit (`49b1b52`) before this docs-sync commit (`e9be31a`) reached it — the same merge-timing race that happened a few times earlier in this session. The commit was never lost (still on the now-orphaned `feat/diag-connection-abstraction` branch), just never landed on `main`. This PR is a clean cherry-pick of exactly that commit onto current `main`, no new content.

## Type of change
- [x] Docs only

## Checklist
- [x] DCO sign-off (preserved from the original commit)
- [x] `ruff check`, `ruff format --check` clean (docs-only, no code)

## How this was tested
N/A — `CHANGELOG.md`/`LOOPS.md` only.