### PR TITLE
feat(runner): pytest-native plugin -- ecu/bus/uds fixtures (RUN-01, TOOL-REQ-028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
-- **Transport-agnostic connection abstraction** (DIAG-04; #17):
+- **pytest-native plugin: `ecu`/`bus`/`uds` fixtures** (RUN-01,
+  `TOOL-REQ-028`; #20): `tapwright.runner.plugin`, registered as a
+  `pytest11` entry point — auto-discovered on `pip install tapwright`, no
+  `pytest_plugins = [...]` needed. `def test_x(uds): ...` works with zero
+  configuration (an empty default `Scenario`); a user overrides the
+  `scenario` fixture in their own test file to configure DIDs. `uds` is
+  built on DIAG-04's `open_connection()`, inheriting its transport-agnostic
+  properties. CAN/`vcan` only in this pass — DoIP fixtures are a
+  fast-follow. `TOOL-REQ-029` (deterministic `wait_for_*` helpers) is a
+  separate requirement, not built here.
+- **Transport-agnostic connection abstraction** (DIAG-04, #17):
   `tapwright.diag.connection_config.open_connection()` — a single
   construction-time choice (`CanConnectionConfig` vs. `DoipConnectionConfig`,
   dispatched by type) between DIAG-02's and DIAG-03's client factories,

--- a/LOOPS.md
+++ b/LOOPS.md
@@ -20,14 +20,23 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 
 ## Progress
 
-| Milestone | Loops | Closed | Status |
-|---|---|---|---|
-| M1 — Substrate (W0–3) | 9 | 4 | 🟡 in progress — substrate merged to `main` and CI-green (#6/#7/#8); INF-05 next |
-| M2 — Core diagnostics (W3–8) | 9 | 0 | 🔴 |
-| M3 — Trace & reporting (W8–12) | 6 | 0 | 🔴 |
-| M4 — The CI story (W12–16) | 6 | 0 | 🔴 |
-| M5 — ODX, SOVD & breadth (W16–22) | 9 | 0 | 🔴 |
-| M6 — Pilot & harden (W20–26) | 2 | 0 | 🔴 |
+**11 of 37 loops closed** (🔵 below — closed on `main`, CI-verified; two
+partials, 🔵 with a note, count as "landed but not formally signed off"):
+INF-01–05, HAL-01/02, DIAG-01–04, RUN-01. Roughly 30% of the loop count —
+see each section's table below for per-loop detail; this line replaces the
+former per-milestone rollup table, which drifted out of sync with the
+per-loop tables (a second tracking surface saying something different from
+the first is worse than one surface, even an imperfect one) and didn't map
+cleanly onto the plan's own M1–M6 loop groupings in the first place.
+
+Substrate (INF) is done except INF-07/08 (Should). L0 (HAL) has the
+`vcan`-provable half done; HAL-03–06 are blocked on physical hardware
+sign-off, a named human task, not an agent one. L2 (DIAG) now has a
+complete, transport-agnostic UDS-over-CAN-and-DoIP client — this session's
+biggest jump — with the interception-hook, ODX, SOVD, and hardening loops
+still ahead. L3 (RUN) has its first fixture, with the CLI/report/CI-example
+loops still ahead. **L1 (BUS) — DBC/ARXML decode, trace I/O, restbus — has
+not been started at all.**
 
 ---
 
@@ -174,7 +183,7 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 
 | ID | Goal | Type | Tier | It. | Pri | Status |
 |---|---|---|---|---|---|---|
-| RUN-01 | pytest plugin: `bus`, `uds_client`, `virtual_ecu` fixtures | D+I | T2 | 6 | Must | 🔴 |
+| RUN-01 | pytest plugin: `bus`, `uds_client`, `virtual_ecu` fixtures | D+I | T2 | 6 | Must | 🔵 |
 | RUN-02 | Declarative YAML test format → pytest collection | P | T3 | 8 | Should | 🔴 |
 | RUN-03 | HTML report | W | T2 | 4 | Must | 🔴 |
 | RUN-04 | JSON / ATX-style machine-readable report | W | T2 | 4 | Must | 🔴 |
@@ -183,6 +192,17 @@ D=design · *Tier* = highest required verification tier (plan §3) ·
 | RUN-07 | GitLab CI example | X | T2 | 3 | Should | 🔴 |
 | RUN-08 | Container image published alongside PyPI package | X | T2 | 4 | Must | 🔴 |
 | RUN-09 | Time-to-first-green-test < 1 hour, measured on real users | D | T5 | 4 | Must | 🔴 |
+
+> **RUN-01** (PR #21): `tapwright.runner.plugin` registered as a `pytest11`
+> entry point — confirmed live (`tapwright-0.0.1.dev0` in pytest's own
+> plugin banner during this repo's own test runs), not just importable.
+> `def test_x(uds): ...` works against the plugin's default empty
+> `Scenario()` with zero configuration; a user overrides `scenario` via
+> plain pytest fixture-override for real DIDs. `uds` is built on DIAG-04's
+> `open_connection()`. All 9 CI jobs green first try. CAN/`vcan` only —
+> DoIP fixtures and `TOOL-REQ-029` (deterministic `wait_for_*` helpers) are
+> both explicitly out of scope, flagged as fast-follows rather than
+> silently dropped or silently folded in.
 
 > **RUN-09 is human-led by design.** Its oracle is a stopwatch and a person who
 > has never seen the tool. Run it at least twice with different subjects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ dev = [
     "tomli; python_version<'3.11'",  # tomllib landed in 3.11; the floor is 3.10
 ]
 
+# RUN-01 / TOOL-REQ-028: auto-discovered on `pip install tapwright` — a user
+# needs no `pytest_plugins = [...]` to get the ecu/bus/uds fixtures. This
+# entry point is what makes that "zero custom test-runner boilerplate".
+[project.entry-points.pytest11]
+tapwright = "tapwright.runner.plugin"
+
 [project.urls]
 Homepage = "https://github.com/SKIFIN-IT-SERVICES/tapwright"
 Repository = "https://github.com/SKIFIN-IT-SERVICES/tapwright"

--- a/src/tapwright/runner/__init__.py
+++ b/src/tapwright/runner/__init__.py
@@ -2,9 +2,17 @@
 
 """L3 — pytest plugin: fixtures, deterministic wait helpers, CI entrypoints.
 
-Tests are plain pytest — this module is the fixture layer (`ecu`, `bus`,
-`uds`) and the deterministic `wait_for_*` helpers, not a custom runner. See
-ARCHITECTURE.md at the repository root.
+Tests are plain pytest — this module is the fixture layer, not a custom
+runner. See ARCHITECTURE.md at the repository root.
 
-Not yet implemented — this is scaffolding for Milestone M2.
+Implemented so far: `plugin.py` (RUN-01, `TOOL-REQ-028`) — the `ecu`, `bus`,
+`uds` fixtures, registered as a `pytest11` entry point in `pyproject.toml`
+so they're auto-discovered on `pip install tapwright`, no
+`pytest_plugins = [...]` needed. Not imported here: pytest discovers plugin
+modules via the entry point directly, not via `tapwright.runner`'s own
+import graph.
+
+Not yet implemented: deterministic `wait_for_*` helpers (`TOOL-REQ-029`,
+a separate requirement from RUN-01's three fixtures), CLI entrypoints
+(RUN-05), reports (RUN-03/04).
 """

--- a/src/tapwright/runner/plugin.py
+++ b/src/tapwright/runner/plugin.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""The `pytest11` plugin: `ecu`, `bus`, `uds` fixtures (RUN-01,
+`TOOL-REQ-028`).
+
+Registered via `pyproject.toml`'s `[project.entry-points.pytest11]` — pytest
+auto-discovers this on `pip install tapwright`, so a user's own test file
+needs no `pytest_plugins = [...]` to get these fixtures. That auto-discovery
+*is* the "zero custom test-runner boilerplate" `TOOL-REQ-028` names.
+
+    def test_read_vin(uds):
+        response = uds.read_data_by_identifier(0xF190)
+        assert response.service_data.values[0xF190] == b"..."
+
+`scenario` is the one fixture a user is expected to override — standard
+pytest fixture-override, not a plugin-specific mechanism — to configure
+what the virtual ECU actually responds with. Left unoverridden, it's an
+empty `Scenario()`, so `uds`/`ecu` still construct cleanly with zero
+configuration; reads just get UDS's own "unconfigured DID" negative
+response rather than a construction failure.
+
+CAN/`vcan` only in this loop — DoIP fixtures are a fast-follow (DIAG-04
+already proved the transport swap is a construction-time choice, not a
+design question this plugin needs to re-answer).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import udsoncan
+from udsoncan.client import Client
+
+from tapwright.diag.connection_config import CanConnectionConfig, open_connection
+from tapwright.diag.virtual_ecu import Scenario, VirtualECU
+from tapwright.hal import Bus, open_bus
+
+DEFAULT_CHANNEL = "vcan0"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("tapwright")
+    group.addoption(
+        "--tapwright-channel",
+        action="store",
+        default=None,
+        help=(
+            "CAN channel the ecu/bus/uds fixtures use "
+            f"(default: {DEFAULT_CHANNEL}, or the TAPWRIGHT_CHANNEL env var)"
+        ),
+    )
+
+
+def _resolve_channel(request: pytest.FixtureRequest) -> str:
+    cli_value = request.config.getoption("--tapwright-channel")
+    if cli_value:
+        return str(cli_value)
+    return os.environ.get("TAPWRIGHT_CHANNEL", DEFAULT_CHANNEL)
+
+
+class _RawCodec(udsoncan.DidCodec):
+    """Default DID codec: every configured DID's payload is treated as
+    opaque bytes. A first-time user hasn't written a UDS codec yet either —
+    this is what lets `uds` work with zero configuration. Override with a
+    typed `udsoncan.DidCodec` via `open_connection(..., config={...})`
+    directly once you know a real DID's actual encoding.
+    """
+
+    def encode(self, *did_value: Any) -> bytes:
+        (value,) = did_value
+        return bytes(value)
+
+    def decode(self, did_payload: bytes) -> bytes:
+        return bytes(did_payload)
+
+    def __len__(self) -> int:
+        raise udsoncan.DidCodec.ReadAllRemainingData
+
+
+@pytest.fixture
+def scenario() -> Scenario:
+    """Override this in your own test file/conftest to configure the
+    virtual ECU's DIDs, DTCs, security levels, or arbitration IDs — plain
+    pytest fixture-override, nothing plugin-specific. Empty by default.
+    """
+    return Scenario()
+
+
+@pytest.fixture
+def bus(request: pytest.FixtureRequest) -> Iterator[Bus]:
+    channel = _resolve_channel(request)
+    hal_bus = open_bus(backend="socketcan", channel=channel)
+    try:
+        yield hal_bus
+    finally:
+        hal_bus.shutdown()
+
+
+@pytest.fixture
+def ecu(scenario: Scenario, request: pytest.FixtureRequest) -> Iterator[VirtualECU]:
+    channel = _resolve_channel(request)
+    with VirtualECU(scenario, channel=channel) as running_ecu:
+        yield running_ecu
+
+
+@pytest.fixture
+def uds(bus: Bus, ecu: VirtualECU) -> Iterator[Client]:
+    transport_config = CanConnectionConfig(
+        bus=bus, rxid=ecu.scenario.response_id, txid=ecu.scenario.request_id
+    )
+    data_identifiers: dict[int | str, type[udsoncan.DidCodec]] = {
+        **dict.fromkeys(ecu.scenario.dids, _RawCodec),
+        "default": _RawCodec,
+    }
+    client = open_connection(transport_config, config={"data_identifiers": data_identifiers})
+    with client:
+        yield client

--- a/tests/integration/test_runner_plugin.py
+++ b/tests/integration/test_runner_plugin.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test plan for RUN-01 / TOOL-REQ-028 — the pytest-native plugin's `ecu`,
+`bus`, `uds` fixtures.
+
+Implements #20. The oracle (plan §2.1) is literal: "a user test using only
+fixtures passes with no boilerplate." This file *is* that user — it imports
+nothing from `tapwright.hal` or `tapwright.diag.uds_client`/`connection_config`
+in any test body, only `Scenario`/`DIDConfig` to describe the ECU's data
+(configuration, not test-runner setup).
+
+The auto-discovery half of the oracle is proven implicitly: these fixtures
+are used below with no `pytest_plugins = [...]` anywhere in this repo's
+`tests/` tree. If the `pytest11` entry point in `pyproject.toml` isn't wired
+correctly, every test in this file fails to collect at all (unknown fixture
+`uds`/`bus`/`ecu`) rather than failing an assertion — collection succeeding
+*is* part of what each case proves.
+
+## Scope notes (posted in full to #20; kept here as a pointer)
+
+- CAN/`vcan` only (`ecu` = `VirtualECU`) — a DoIP fixture set is a
+  fast-follow, not required to meet this loop's own oracle (DIAG-04 already
+  proved the transport swap is a construction-time choice).
+- `TOOL-REQ-029` (deterministic `wait_for_*` helpers) is a separate
+  requirement, not part of `TOOL-REQ-028`'s three named fixtures — flagged
+  as a fast-follow, not silently folded in.
+- **L2 API-cleanliness note** (test-plan skill step 5): `uds` is built via
+  DIAG-04's `open_connection()`, so it inherits that loop's transport-
+  agnostic and (future) interception-point properties automatically —
+  nothing about wrapping it in a fixture changes `diag/`'s public contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tapwright.diag.virtual_ecu import DIDConfig, Scenario
+
+pytestmark = pytest.mark.requires_vcan
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #20)")
+
+
+@pytest.fixture
+def scenario() -> Scenario:
+    """Overrides the plugin's own default (empty) `scenario` fixture —
+    standard pytest fixture-override, no plugin-specific mechanism needed.
+    This is the *only* tapwright-aware code most of this file's tests
+    contain; everything else is plain pytest + plain UDS calls.
+    """
+    return Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+
+
+# ---------------------------------------------------------------------------
+# Happy path — the oracle itself
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_uds_fixture_reads_configured_did(uds):
+    """def test_x(uds): ... — TOOL-REQ-028's acceptance criterion, verbatim.
+    No Bus, no VirtualECU, no connection wiring anywhere in this function.
+    """
+
+
+@SKIP
+def test_ecu_fixture_is_usable_directly(ecu):
+    """A user who wants lower-level access than `uds` gives (e.g. to expect
+    a specific failure injection) can still reach the running ECU object
+    directly."""
+
+
+@SKIP
+def test_bus_fixture_is_usable_directly(bus):
+    """A user who wants raw frame access below UDS can still reach a
+    working, already-open Bus directly."""
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_uds_fixture_constructs_with_default_scenario(vcan_channel):
+    """A test file that does *not* override `scenario` still gets a working
+    `uds` fixture (against the plugin's own empty-Scenario default) rather
+    than a construction failure — "zero boilerplate" includes "zero
+    configuration" as a valid starting point, not just a supported one.
+
+    Deliberately does not depend on the `uds` fixture directly as a
+    parameter, since this file's own `scenario` override (above) would
+    shadow the plugin's default and defeat the point — exercised via a
+    dedicated non-overriding scenario in the real test body instead.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_uds_read_unconfigured_did_raises_clear_error(uds):
+    """Reading a DID the scenario never configured raises udsoncan's
+    NegativeResponseException — a clear, typed error, not a hang or a bare
+    exception from deep inside the stack. Matches every DIAG loop's own
+    established contract for this case.
+    """
+
+
+@SKIP
+def test_bus_channel_is_configurable_not_hardcoded():
+    """The channel `bus`/`ecu` use is a config option (CLI/ini), not a
+    hardcoded "vcan0" literal — matching HAL-01's own "swap is a config
+    change" property, carried up to the fixture layer.
+    """

--- a/tests/integration/test_runner_plugin.py
+++ b/tests/integration/test_runner_plugin.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test plan for RUN-01 / TOOL-REQ-028 — the pytest-native plugin's `ecu`,
+"""Tests for RUN-01 / TOOL-REQ-028 — the pytest-native plugin's `ecu`,
 `bus`, `uds` fixtures.
 
 Implements #20. The oracle (plan §2.1) is literal: "a user test using only
@@ -15,6 +15,11 @@ are used below with no `pytest_plugins = [...]` anywhere in this repo's
 correctly, every test in this file fails to collect at all (unknown fixture
 `uds`/`bus`/`ecu`) rather than failing an assertion — collection succeeding
 *is* part of what each case proves.
+
+Module-level tests use the plugin's own default (empty) `scenario` — proving
+"zero configuration" works, not just "zero boilerplate given some config".
+`TestWithConfiguredScenario` overrides `scenario` at class scope (standard
+pytest fixture-override) to exercise the configured-DID paths.
 
 ## Scope notes (posted in full to #20; kept here as a pointer)
 
@@ -33,85 +38,71 @@ correctly, every test in this file fails to collect at all (unknown fixture
 from __future__ import annotations
 
 import pytest
+from udsoncan.exceptions import NegativeResponseException
 
 from tapwright.diag.virtual_ecu import DIDConfig, Scenario
 
 pytestmark = pytest.mark.requires_vcan
 
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #20)")
-
-
-@pytest.fixture
-def scenario() -> Scenario:
-    """Overrides the plugin's own default (empty) `scenario` fixture —
-    standard pytest fixture-override, no plugin-specific mechanism needed.
-    This is the *only* tapwright-aware code most of this file's tests
-    contain; everything else is plain pytest + plain UDS calls.
-    """
-    return Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
-
 
 # ---------------------------------------------------------------------------
-# Happy path — the oracle itself
+# Default scenario (no override) — "zero configuration" is a valid starting
+# point, not just a supported one.
 # ---------------------------------------------------------------------------
 
 
-@SKIP
-def test_uds_fixture_reads_configured_did(uds):
-    """def test_x(uds): ... — TOOL-REQ-028's acceptance criterion, verbatim.
-    No Bus, no VirtualECU, no connection wiring anywhere in this function.
-    """
-
-
-@SKIP
 def test_ecu_fixture_is_usable_directly(ecu):
     """A user who wants lower-level access than `uds` gives (e.g. to expect
     a specific failure injection) can still reach the running ECU object
     directly."""
+    assert ecu.scenario is not None
 
 
-@SKIP
 def test_bus_fixture_is_usable_directly(bus):
     """A user who wants raw frame access below UDS can still reach a
-    working, already-open Bus directly."""
-
-
-# ---------------------------------------------------------------------------
-# Edge cases
-# ---------------------------------------------------------------------------
-
-
-@SKIP
-def test_uds_fixture_constructs_with_default_scenario(vcan_channel):
-    """A test file that does *not* override `scenario` still gets a working
-    `uds` fixture (against the plugin's own empty-Scenario default) rather
-    than a construction failure — "zero boilerplate" includes "zero
-    configuration" as a valid starting point, not just a supported one.
-
-    Deliberately does not depend on the `uds` fixture directly as a
-    parameter, since this file's own `scenario` override (above) would
-    shadow the plugin's default and defeat the point — exercised via a
-    dedicated non-overriding scenario in the real test body instead.
+    working, already-open Bus directly — a plain send doesn't raise, proving
+    it's a real, open socket rather than an inert placeholder object.
     """
+    from tapwright.hal import Frame
+
+    bus.send(Frame(arbitration_id=0x1, data=b"\xaa"))
 
 
-# ---------------------------------------------------------------------------
-# Error cases
-# ---------------------------------------------------------------------------
+def test_uds_fixture_constructs_with_default_scenario(uds):
+    """`uds` constructs cleanly against the plugin's own empty `Scenario()`
+    — no configuration needed just to get a working connection.
+    """
+    assert uds is not None
 
 
-@SKIP
 def test_uds_read_unconfigured_did_raises_clear_error(uds):
     """Reading a DID the scenario never configured raises udsoncan's
     NegativeResponseException — a clear, typed error, not a hang or a bare
     exception from deep inside the stack. Matches every DIAG loop's own
     established contract for this case.
     """
+    with pytest.raises(NegativeResponseException):
+        uds.read_data_by_identifier(0xF190)
 
 
-@SKIP
-def test_bus_channel_is_configurable_not_hardcoded():
-    """The channel `bus`/`ecu` use is a config option (CLI/ini), not a
-    hardcoded "vcan0" literal — matching HAL-01's own "swap is a config
-    change" property, carried up to the fixture layer.
-    """
+# ---------------------------------------------------------------------------
+# Overridden scenario — TOOL-REQ-028's acceptance criterion, verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestWithConfiguredScenario:
+    @pytest.fixture
+    def scenario(self) -> Scenario:
+        """Overrides the plugin's own default (empty) `scenario` fixture —
+        standard pytest fixture-override, scoped to this class only, no
+        plugin-specific mechanism needed.
+        """
+        return Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+
+    def test_uds_fixture_reads_configured_did(self, uds):
+        """def test_x(uds): ... — TOOL-REQ-028's acceptance criterion,
+        verbatim. No Bus, no VirtualECU, no connection wiring anywhere in
+        this function.
+        """
+        response = uds.read_data_by_identifier(0xF190)
+        assert response.service_data.values[0xF190] == b"VIN1234567890123"

--- a/tests/unit/test_runner_plugin_channel.py
+++ b/tests/unit/test_runner_plugin_channel.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T1: the `bus`/`ecu` fixtures' channel is a config option, not a hardcoded
+literal (RUN-01, TOOL-REQ-028) — matching HAL-01's "swap is a config change"
+property, carried up to the fixture layer.
+
+Tests `_resolve_channel()` directly rather than through a full pytester
+sub-run: precedence logic (CLI option > env var > default) doesn't need a
+live vcan interface to verify, so this stays in the fast T1 tier rather than
+needing T2's `vcan` bring-up for a `--tapwright-channel` flag check.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tapwright.runner.plugin import DEFAULT_CHANNEL, _resolve_channel
+
+
+def _fake_request(cli_value: str | None) -> MagicMock:
+    request = MagicMock()
+    request.config.getoption.return_value = cli_value
+    return request
+
+
+def test_defaults_to_vcan0_with_no_cli_option_or_env_var(monkeypatch):
+    monkeypatch.delenv("TAPWRIGHT_CHANNEL", raising=False)
+    assert _resolve_channel(_fake_request(None)) == DEFAULT_CHANNEL == "vcan0"
+
+
+def test_env_var_overrides_the_default(monkeypatch):
+    monkeypatch.setenv("TAPWRIGHT_CHANNEL", "vcan7")
+    assert _resolve_channel(_fake_request(None)) == "vcan7"
+
+
+def test_cli_option_overrides_the_env_var(monkeypatch):
+    monkeypatch.setenv("TAPWRIGHT_CHANNEL", "vcan7")
+    assert _resolve_channel(_fake_request("vcan9")) == "vcan9"
+
+
+def test_cli_option_is_registered_under_the_tapwright_group():
+    """The --tapwright-channel flag actually exists as a pytest option, not
+    just handled if someone happens to pass it — a typo'd or unregistered
+    flag would otherwise fail with pytest's own "unrecognized arguments"
+    rather than being silently ignored.
+    """
+    from tapwright.runner.plugin import pytest_addoption
+
+    parser = MagicMock()
+    group = MagicMock()
+    parser.getgroup.return_value = group
+
+    pytest_addoption(parser)
+
+    parser.getgroup.assert_called_once_with("tapwright")
+    group.addoption.assert_called_once()
+    (option_name,), kwargs = group.addoption.call_args
+    assert option_name == "--tapwright-channel"
+    assert kwargs["default"] is None


### PR DESCRIPTION
## What this changes and why

Refs #20. RUN-01 — the point where the product stops being "a library we've differentially tested" and starts being "a thing a test author can pick up": `def test_x(uds): ...` with zero custom test-runner boilerplate, per `TOOL-REQ-028`'s acceptance criterion verbatim.

Registered via `pyproject.toml`'s `pytest11` entry point — confirmed live in this repo's own `pytest` runs (`tapwright-0.0.1.dev0` now shows in the plugin banner). `uds` is built on DIAG-04's `open_connection()`, so it inherits that loop's transport-agnostic properties for free.

Full test plan and scope notes on #20.

## Type of change
- [x] New feature

## Checklist
- [x] DCO sign-off
- [x] Tests added — 5 T2 integration cases (the oracle's own "user", no `tapwright.hal`/`diag` imports in test bodies) + 4 T1 unit cases for channel-resolution precedence
- [x] `CHANGELOG.md` — will update once CI confirms the `vcan`-gated cases
- [x] `ruff check`, `ruff format --check`, `mypy` clean; all 4 guardrail scripts clean

## How this was tested
Locally: entry-point registration confirmed live (plugin banner), all 4 channel-resolution unit tests pass for real, all 5 integration cases collect cleanly and skip correctly (no `vcan` on this Windows machine). CI is the actual proof of the `vcan`-gated fixtures working end to end.