### PR TITLE
feat(diag): request/response interception hooks (DIAG-05)

### DIFF
--- a/src/tapwright/diag/interception.py
+++ b/src/tapwright/diag/interception.py
@@ -90,7 +90,16 @@ class InterceptingConnection(BaseConnection):
         self._inner.close()
 
     def is_open(self) -> bool:
-        return self._inner.is_open()
+        # Deliberately not just `self._inner.is_open()`: some inner
+        # connections (e.g. TapwrightIsoTpConnection) report themselves open
+        # immediately at construction, since their underlying transport is
+        # already running. If is_open() delegated to the inner connection
+        # alone, udsoncan.Client.open()'s `if not self.conn.is_open():
+        # self.conn.open()` guard would see True before this wrapper's own
+        # open() -- which binds the listening socket -- ever ran, and the
+        # observer socket would never come up. `self._server is not None`
+        # is this wrapper's own state, set only inside open().
+        return self._server is not None and self._inner.is_open()
 
     def empty_rxqueue(self) -> None:
         self._inner.empty_rxqueue()


### PR DESCRIPTION
## Summary
Re-opens the work from #26, which was merged before CI had actually gone green on the fix commit (`7973bbc`) and was subsequently reverted via #27. `main` currently has none of this code. This PR carries the same branch (`feat/diag-interception-hooks`), now including the `is_open()` fix that #26's CI run never got to validate.

- Adds `InterceptingConnection`, wrapping any `udsoncan.connections.BaseConnection` (CAN or DoIP, transport-agnostic by construction) to publish every outbound request / inbound response to at most one connected observer over a plain TCP + newline-delimited-JSON protocol — the process-boundary interception point `docs/architecture.md` §4's second bullet requires (ADR-004: boofuzz/CaringCaribou are GPL, so a future Gallia-based fuzzer must live in a separate repo and can't be linked in-process).
- No observer attached (the default): one non-blocking `accept()` per message, no thread, no added latency.
- Unresponsive / disconnecting / malformed-reply observers all fall back to passthrough rather than blocking or crashing the session.
- Fixes a real bug caught by #26's own CI: `is_open()` was proxying straight to the inner connection, which some inner connections (`TapwrightIsoTpConnection`) report as open immediately at construction — so `udsoncan.Client.open()`'s `if not is_open(): open()` guard never actually called our `open()`, and the observer's listening socket never bound. `is_open()` now also requires this wrapper's own `_server` to be set.
- Replaces the 8 skip-stubbed test cases from the DIAG-05 test plan (`ee1d738`) with real bodies: 7 CAN/vcan-gated cases plus one DoIP case (plain TCP, runs everywhere) against the virtual ECU.

Closes #25.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src` — clean
- [x] `tools/check_spdx.py`, `check_licences.py`, `check_fixtures.py`, `check_forbidden.py`, `check_blast_radius.py` — all pass
- [x] `pytest -q` locally (Windows, no vcan): 125 passed, 78 skipped
- [x] CI (vcan tier T3/differential, coverage ratchet) — pending, this is what #26's merge skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)