### PR TITLE
feat(diag): request/response interception hooks (DIAG-05)

### DIFF
--- a/src/tapwright/diag/__init__.py
+++ b/src/tapwright/diag/__init__.py
@@ -17,9 +17,12 @@ responder — CAN via `ecu.py`/`transport.py`, DoIP via
 `isotp_transport` (DIAG-01, ISO-TP over `hal.Bus`), `uds_client` +
 `connection` (DIAG-02, the CAN-side client — `open_uds_client()`),
 `doip_client` (DIAG-03, the DoIP-side client — `open_doip_uds_client()`),
-and `connection_config` (DIAG-04 — `open_connection()`, the
-transport-agnostic construction point that dispatches to whichever of the
-two the caller's config object names). Submodules are accessed directly
+`connection_config` (DIAG-04 — `open_connection()`, the transport-agnostic
+construction point that dispatches to whichever of the two the caller's
+config object names), and `interception` (DIAG-05 —
+`InterceptingConnection`, the process-boundary request/response
+interception point `docs/architecture.md` §4's second bullet requires).
+Submodules are accessed directly
 (`tapwright.diag.connection_config`, etc.) rather than re-exported here, so
 importing `tapwright.diag` itself stays cheap — it doesn't pull in
 `can`/`isotp`/`udsoncan`/`doipclient` unless a submodule that actually

--- a/src/tapwright/diag/interception.py
+++ b/src/tapwright/diag/interception.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request/response interception, working across a process boundary
+(DIAG-05, `TOOL-REQ-027`, ADR-004).
+
+Per `docs/architecture.md` §4's second bullet — the one every prior DIAG
+loop noted as "not built yet, but the API must not preclude it": `boofuzz`
+(GPL-2.0) and CaringCaribou (GPL-3.0) can't be linked into a proprietary L4
+in-process (C-9's reasoning extends to GPL), so a future Gallia-based
+fuzzer, in a separate repository, has to talk to this connection across a
+real process boundary — not a Python callback, not a thread.
+
+`InterceptingConnection` wraps *any* existing
+`udsoncan.connections.BaseConnection` (transport-agnostic by construction —
+it doesn't know or care whether the wrapped connection is CAN or DoIP,
+reusing DIAG-04's `open_connection()`'s "one client type either way"
+property) and publishes every outbound request / inbound response to at
+most one connected observer, over a plain TCP socket speaking
+newline-delimited JSON:
+
+    {"type": "request"|"response", "data": "<hex>"}
+
+An observer replies with one line, either:
+
+    {"action": "replace", "data": "<hex>"}   # substitute the payload
+    {"action": "observe"}                     # (or anything else) pass through
+
+With no observer connected — the default, overwhelmingly common case —
+publishing costs one non-blocking `accept()` call that returns immediately:
+no thread, no polling loop, no added latency on the hot path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+from typing import Any
+
+from udsoncan.connections import BaseConnection
+
+_logger = logging.getLogger(__name__)
+
+# How long to wait for a connected observer's reply before assuming it's
+# unresponsive and falling back to passthrough. A misbehaving external
+# process must not become a denial-of-service on the diagnostic session.
+REPLY_TIMEOUT = 2.0
+
+
+class InterceptingConnection(BaseConnection):
+    """Wraps `inner` (any `BaseConnection`), publishing every request and
+    response to at most one connected observer.
+    """
+
+    def __init__(
+        self,
+        inner: BaseConnection,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name)
+        self._inner = inner
+        self._host = host
+        self._requested_port = port
+        self._server: socket.socket | None = None
+        self._client: socket.socket | None = None
+        self._client_buffer = b""
+        self.bound_port: int | None = None
+
+    def open(self) -> InterceptingConnection:
+        self._inner.open()
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind((self._host, self._requested_port))
+        server.listen(1)
+        server.setblocking(False)  # accept() must never block the hot path
+
+        self.bound_port = server.getsockname()[1]
+        self._server = server
+        return self
+
+    def close(self) -> None:
+        self._drop_client()
+        if self._server is not None:
+            self._server.close()
+            self._server = None
+        self._inner.close()
+
+    def is_open(self) -> bool:
+        # Deliberately not just `self._inner.is_open()`: some inner
+        # connections (e.g. TapwrightIsoTpConnection) report themselves open
+        # immediately at construction, since their underlying transport is
+        # already running. If is_open() delegated to the inner connection
+        # alone, udsoncan.Client.open()'s `if not self.conn.is_open():
+        # self.conn.open()` guard would see True before this wrapper's own
+        # open() -- which binds the listening socket -- ever ran, and the
+        # observer socket would never come up. `self._server is not None`
+        # is this wrapper's own state, set only inside open().
+        return self._server is not None and self._inner.is_open()
+
+    def empty_rxqueue(self) -> None:
+        self._inner.empty_rxqueue()
+
+    def specific_send(self, payload: bytes, timeout: float | None = None) -> None:
+        published = self._publish("request", payload)
+        self._inner.send(published, timeout=timeout)
+
+    def specific_wait_frame(self, timeout: float | None = None) -> bytes | None:
+        payload = self._inner.wait_frame(timeout=timeout)
+        if payload is None:
+            return None
+        return self._publish("response", payload)
+
+    # -- interception protocol -----------------------------------------
+
+    def _ensure_client(self) -> socket.socket | None:
+        """Return the connected observer, accepting a newly-pending one if
+        there's no client yet. Never blocks: a non-blocking accept() either
+        finds a connection immediately or doesn't, per `open()`'s own
+        non-blocking listening socket.
+        """
+        if self._client is not None:
+            return self._client
+        assert self._server is not None, "InterceptingConnection.open() was not called"
+        try:
+            client, _addr = self._server.accept()
+        except BlockingIOError:
+            return None
+        client.settimeout(REPLY_TIMEOUT)
+        self._client = client
+        self._client_buffer = b""
+        return client
+
+    def _drop_client(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.close()
+            except OSError:
+                pass
+        self._client = None
+        self._client_buffer = b""
+
+    def _read_line(self, client: socket.socket) -> str | None:
+        while b"\n" not in self._client_buffer:
+            chunk = client.recv(4096)
+            if not chunk:
+                return None  # observer closed the connection
+            self._client_buffer += chunk
+        line, _, self._client_buffer = self._client_buffer.partition(b"\n")
+        return line.decode()
+
+    def _publish(self, kind: str, payload: bytes) -> bytes:
+        client = self._ensure_client()
+        if client is None:
+            return payload  # no observer attached: pure passthrough
+
+        message = json.dumps({"type": kind, "data": payload.hex()}) + "\n"
+        try:
+            client.sendall(message.encode())
+            line = self._read_line(client)
+        except OSError:
+            _logger.debug("interception observer connection error; dropping and passing through")
+            self._drop_client()
+            return payload
+
+        if line is None:
+            _logger.debug("interception observer disconnected; dropping and passing through")
+            self._drop_client()
+            return payload
+
+        try:
+            reply: dict[str, Any] = json.loads(line)
+        except json.JSONDecodeError:
+            _logger.debug(
+                "interception observer sent malformed reply; dropping and passing through"
+            )
+            self._drop_client()
+            return payload
+
+        if reply.get("action") == "replace":
+            try:
+                return bytes.fromhex(reply["data"])
+            except (KeyError, ValueError):
+                _logger.debug(
+                    "interception observer sent an invalid replace payload; passing through"
+                )
+                return payload
+
+        return payload

--- a/tests/differential/_interception_observer.py
+++ b/tests/differential/_interception_observer.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""A standalone third-party observer process for DIAG-05's test suite.
+
+Deliberately imports **nothing** from `tapwright` — this script simulates an
+external tool (a future Gallia-based fuzzer, in a separate repository, per
+ADR-004) that only ever speaks the plain newline-delimited-JSON protocol
+over a TCP socket. If this script needed a `tapwright` import to work, the
+interception point wouldn't actually be usable "without forking," which is
+the whole point of DIAG-05.
+
+Connects once and stays connected for the rest of the session (matching
+realistic fuzzer usage — attach once, observe/mutate many messages), reading
+one published message at a time in a loop until the connection closes or
+`--messages` is exhausted.
+
+Usage (spawned as a subprocess by the test suite, never imported directly):
+
+    python _interception_observer.py <port> --messages N [--replace TYPE:HEX]
+
+`--messages N`: exit after N messages (0 = until the connection closes).
+`--replace TYPE:HEX`: for a published message of `"type": TYPE`
+    ("request"/"response"), reply with a `replace` action substituting the
+    given hex payload. Every other message type is passed through
+    unmodified (an `observe` reply). Repeatable.
+`--silent`: never reply to anything — simulates an unresponsive observer.
+`--garbage`: reply with invalid JSON to everything — simulates a
+    misbehaving observer.
+
+Prints one line of JSON per message received, so the test process (reading
+this script's stdout) can assert on exactly what the interception point
+published, independent of what this script did in response.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("port", type=int)
+    parser.add_argument("--messages", type=int, default=0)
+    parser.add_argument("--replace", action="append", default=[])
+    parser.add_argument("--silent", action="store_true")
+    parser.add_argument("--garbage", action="store_true")
+    args = parser.parse_args()
+
+    replacements = dict(item.split(":", 1) for item in args.replace)
+
+    with socket.create_connection(("127.0.0.1", args.port), timeout=5.0) as sock:
+        sock.settimeout(5.0)
+        buffer = b""
+        received = 0
+        while args.messages == 0 or received < args.messages:
+            while b"\n" not in buffer:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    return 0  # peer closed the connection
+                buffer += chunk
+            line, _, buffer = buffer.partition(b"\n")
+            received += 1
+            message = json.loads(line.decode())
+            print(json.dumps(message), flush=True)
+
+            if args.silent:
+                continue
+            if args.garbage:
+                sock.sendall(b"not valid json at all\n")
+                continue
+
+            message_type = message.get("type")
+            if message_type in replacements:
+                reply = {"action": "replace", "data": replacements[message_type]}
+            else:
+                reply = {"action": "observe"}
+            sock.sendall((json.dumps(reply) + "\n").encode())
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/differential/test_interception.py
+++ b/tests/differential/test_interception.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T2 tests for DIAG-05 — request/response interception hooks, working
+across a process boundary.
+
+Implements #25. The oracle (plan §2.1, DIAG-05's own backlog line, verbatim):
+"A third-party wrapper can observe and modify a request/response without
+forking, from a separate process." Every case below spawns a genuine OS
+subprocess (`_interception_observer.py`, imports nothing from `tapwright`)
+as the "third party" — not an in-process mock, not a thread. That subprocess
+speaks only the plain newline-delimited-JSON protocol
+`InterceptingConnection` publishes over a TCP socket.
+
+Most cases are CAN/`vcan`-based (marked individually, not at module scope,
+since the DoIP case at the bottom needs no `vcan` at all — matching
+DIAG-03's own no-module-mark precedent).
+
+## Scope notes
+
+- Single observer at a time — multi-observer fan-out is a fast-follow, not
+  required by this loop's oracle.
+- **L2 API-cleanliness note** (test-plan skill step 5): this loop *is*
+  `docs/architecture.md` §4's second bullet, the one every prior DIAG loop
+  noted as "not built yet, but not precluded." It's transport-agnostic by
+  construction (wraps whatever `BaseConnection` DIAG-04's `open_connection()`
+  produces), so it doesn't reopen or special-case CAN vs. DoIP.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from doipclient import DoIPClient
+from doipclient.connectors import DoIPClientUDSConnector
+from udsoncan.client import Client
+from udsoncan.configs import default_client_config
+
+from tapwright.diag.connection import TapwrightIsoTpConnection
+from tapwright.diag.interception import InterceptingConnection
+from tapwright.diag.isotp_transport import IsoTpTransport
+from tapwright.diag.virtual_ecu import DIDConfig, DoIPVirtualECU, Scenario, VirtualECU
+from tapwright.hal import open_bus
+
+OBSERVER_SCRIPT = Path(__file__).resolve().parent / "_interception_observer.py"
+DOIP_ECU_HOST = "127.0.0.1"
+DOIP_ECU_LOGICAL_ADDRESS = 0x0001
+DOIP_CLIENT_LOGICAL_ADDRESS = 0xE00
+
+# Time to let a spawned observer's TCP connect land in the listening
+# backlog before the intercepted call that should pick it up. The connect
+# itself is near-instant on localhost; this covers subprocess startup.
+OBSERVER_SETTLE_TIME = 0.3
+
+
+def spawn_observer(port: int | None, *args: str) -> subprocess.Popen:
+    """A real OS subprocess — the "separate process" the oracle requires.
+
+    `port` is `int | None` because it mirrors `InterceptingConnection.bound_port`,
+    which is only ever `None` before `open()` — by the time a test calls this,
+    the connection is already open, but the assert documents that invariant
+    rather than silently accepting `None`.
+    """
+    assert port is not None, "InterceptingConnection.open() must run before spawning an observer"
+    return subprocess.Popen(
+        [sys.executable, str(OBSERVER_SCRIPT), str(port), *args],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+
+def read_observer_messages(proc: subprocess.Popen, count: int) -> list[dict]:
+    assert proc.stdout is not None
+    messages = []
+    for _ in range(count):
+        line = proc.stdout.readline()
+        if not line:
+            break
+        messages.append(json.loads(line))
+    return messages
+
+
+def client_config(scenario: Scenario, raw_did_codec) -> dict:
+    data_identifiers = {**dict.fromkeys(scenario.dids, raw_did_codec), "default": raw_did_codec}
+    config = dict(default_client_config)
+    config["data_identifiers"] = data_identifiers
+    return config
+
+
+@contextlib.contextmanager
+def intercepted_can_client(scenario: Scenario, vcan_channel: str, raw_did_codec):
+    bus = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        with VirtualECU(scenario, channel=vcan_channel):
+            transport = IsoTpTransport(bus, rxid=scenario.response_id, txid=scenario.request_id)
+            intercepting = InterceptingConnection(TapwrightIsoTpConnection(transport))
+            with Client(intercepting, config=client_config(scenario, raw_did_codec)) as client:
+                yield client, intercepting
+    finally:
+        bus.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_vcan
+def test_observer_process_observes_request_and_response_without_modifying(
+    vcan_channel, raw_did_codec
+):
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with intercepted_can_client(scenario, vcan_channel, raw_did_codec) as (client, intercepting):
+        observer = spawn_observer(intercepting.bound_port, "--messages", "2")
+        time.sleep(OBSERVER_SETTLE_TIME)
+        response = client.read_data_by_identifier(0xF190)
+        observer.wait(timeout=5.0)
+
+    assert response.service_data.values[0xF190] == b"VIN1234567890123"
+    messages = read_observer_messages(observer, 2)
+    assert [m["type"] for m in messages] == ["request", "response"]
+
+
+@pytest.mark.requires_vcan
+def test_observer_process_can_replace_a_response(vcan_channel, raw_did_codec):
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    replacement = bytes([0x62, 0xF1, 0x90]) + b"REPLACEDVALUE"
+
+    with intercepted_can_client(scenario, vcan_channel, raw_did_codec) as (client, intercepting):
+        observer = spawn_observer(
+            intercepting.bound_port, "--messages", "2", "--replace", f"response:{replacement.hex()}"
+        )
+        time.sleep(OBSERVER_SETTLE_TIME)
+        response = client.read_data_by_identifier(0xF190)
+        observer.wait(timeout=5.0)
+
+    assert response.service_data.values[0xF190] == b"REPLACEDVALUE"
+
+
+@pytest.mark.requires_vcan
+def test_observer_process_can_replace_a_request(vcan_channel, raw_did_codec):
+    """The observer rewrites an outbound WriteDataByIdentifier request's
+    *value* before it reaches the ECU. Reading the DID back afterward
+    (with no observer attached — pure passthrough by then) shows the ECU
+    stored what the observer substituted, not what the caller originally
+    asked to write — proof the ECU actually received the mutated request.
+    """
+    scenario = Scenario(dids={0x1234: DIDConfig(value=b"\x00\x00")})
+    mutated_value = b"\xbb\xbb"
+    replacement_request = bytes([0x2E, 0x12, 0x34]) + mutated_value
+
+    with intercepted_can_client(scenario, vcan_channel, raw_did_codec) as (client, intercepting):
+        observer = spawn_observer(
+            intercepting.bound_port,
+            "--messages",
+            "2",
+            "--replace",
+            f"request:{replacement_request.hex()}",
+        )
+        time.sleep(OBSERVER_SETTLE_TIME)
+        client.write_data_by_identifier(0x1234, b"\xaa\xaa")
+        observer.wait(timeout=5.0)
+
+        result = client.read_data_by_identifier(0x1234).service_data.values[0x1234]
+
+    assert result == mutated_value
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_vcan
+def test_no_observer_attached_is_pure_passthrough(vcan_channel, raw_did_codec):
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with intercepted_can_client(scenario, vcan_channel, raw_did_codec) as (client, _intercepting):
+        start = time.monotonic()
+        response = client.read_data_by_identifier(0xF190)
+        elapsed = time.monotonic() - start
+
+    assert response.service_data.values[0xF190] == b"VIN1234567890123"
+    # No observer ever connects in this test: publishing is one non-blocking
+    # accept() per message. A generous bound (normal vcan round-trips are
+    # single-digit milliseconds) that would still catch an accidental
+    # blocking-accept regression.
+    assert elapsed < 1.0
+
+
+@pytest.mark.requires_vcan
+def test_observer_disconnecting_mid_session_falls_back_to_passthrough(vcan_channel, raw_did_codec):
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with intercepted_can_client(scenario, vcan_channel, raw_did_codec) as (client, intercepting):
+        # Observes exactly the request, then exits -- closed before the
+        # response is published.
+        observer = spawn_observer(intercepting.bound_port, "--messages", "1")
+        time.sleep(OBSERVER_SETTLE_TIME)
+        response = client.read_data_by_identifier(0xF190)
+        observer.wait(timeout=5.0)
+
+    assert response.service_data.values[0xF190] == b"VIN1234567890123"
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_vcan
+def test_unresponsive_observer_does_not_block_traffic_forever(vcan_channel, raw_did_codec):
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with intercepted_can_client(scenario, vcan_channel, raw_did_codec) as (client, intercepting):
+        observer = spawn_observer(intercepting.bound_port, "--messages", "1", "--silent")
+        time.sleep(OBSERVER_SETTLE_TIME)
+        start = time.monotonic()
+        response = client.read_data_by_identifier(0xF190)
+        elapsed = time.monotonic() - start
+        observer.terminate()
+        observer.wait(timeout=5.0)
+
+    assert response.service_data.values[0xF190] == b"VIN1234567890123"
+    assert elapsed < 10.0  # bounded (REPLY_TIMEOUT-scale), not indefinite
+
+
+@pytest.mark.requires_vcan
+def test_malformed_observer_reply_is_ignored_not_crashing(vcan_channel, raw_did_codec):
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with intercepted_can_client(scenario, vcan_channel, raw_did_codec) as (client, intercepting):
+        observer = spawn_observer(intercepting.bound_port, "--messages", "1", "--garbage")
+        time.sleep(OBSERVER_SETTLE_TIME)
+        response = client.read_data_by_identifier(0xF190)
+        observer.wait(timeout=5.0)
+
+    assert response.service_data.values[0xF190] == b"VIN1234567890123"
+
+
+# ---------------------------------------------------------------------------
+# Transport-agnosticism — no requires_vcan: DoIP is plain TCP
+# ---------------------------------------------------------------------------
+
+
+def test_interception_wraps_a_doip_connection_identically(raw_did_codec):
+    """InterceptingConnection wraps whatever BaseConnection DIAG-04's
+    open_connection() produces — confirmed once here against a DoIP-backed
+    connection, not re-running the full observe/replace matrix a second
+    time (DIAG-04 already established transport-agnosticism as a property
+    of the underlying connection types; this only confirms interception
+    doesn't special-case CAN).
+    """
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"VIN1234567890123")})
+    with DoIPVirtualECU(
+        scenario, host=DOIP_ECU_HOST, ecu_logical_address=DOIP_ECU_LOGICAL_ADDRESS
+    ) as ecu:
+        doip_layer = DoIPClient(
+            DOIP_ECU_HOST,
+            DOIP_ECU_LOGICAL_ADDRESS,
+            tcp_port=ecu.port,
+            client_logical_address=DOIP_CLIENT_LOGICAL_ADDRESS,
+        )
+        intercepting = InterceptingConnection(
+            DoIPClientUDSConnector(doip_layer, close_connection=True)
+        )
+        with Client(intercepting, config=client_config(scenario, raw_did_codec)) as client:
+            observer = spawn_observer(intercepting.bound_port, "--messages", "2")
+            time.sleep(OBSERVER_SETTLE_TIME)
+            response = client.read_data_by_identifier(0xF190)
+            observer.wait(timeout=5.0)
+
+    assert response.service_data.values[0xF190] == b"VIN1234567890123"
+    messages = read_observer_messages(observer, 2)
+    assert [m["type"] for m in messages] == ["request", "response"]


### PR DESCRIPTION
## Summary
Third attempt at this loop, rebuilt on a clean branch off current `main` after #26 and #28 both got tangled in a merge/revert cycle (#26 was merged before its is_open() fix had gone through CI and was reverted; #28's merge-base against main was left in a state where a plain merge would have deleted the new test files). `main` currently has none of this code — this PR carries the complete, CI-clean-locally implementation.

- Adds `InterceptingConnection`, wrapping any `udsoncan.connections.BaseConnection` (CAN or DoIP, transport-agnostic by construction) to publish every outbound request / inbound response to at most one connected observer over a plain TCP + newline-delimited-JSON protocol — the process-boundary interception point `docs/architecture.md` §4's second bullet requires (ADR-004: boofuzz/CaringCaribou are GPL, so a future Gallia-based fuzzer must live in a separate repo and can't be linked in-process).
- No observer attached (the default): one non-blocking `accept()` per message, no thread, no added latency.
- Unresponsive / disconnecting / malformed-reply observers all fall back to passthrough rather than blocking or crashing the session.
- `is_open()` deliberately does not proxy straight to the inner connection: some inner connections (`TapwrightIsoTpConnection`) report themselves open immediately at construction, which would make `udsoncan.Client.open()`'s `if not is_open(): open()` guard skip calling this wrapper's own `open()` — the one that binds the listening socket — entirely. `is_open()` also requires this wrapper's own `_server` to be set.
- Replaces the 8 skip-stubbed test cases from the DIAG-05 test plan (`ee1d738`) with real bodies: 7 CAN/vcan-gated cases plus one DoIP case (plain TCP, runs everywhere) against the virtual ECU.

Closes #25.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src` — clean
- [x] `tools/check_spdx.py`, `check_licences.py`, `check_fixtures.py`, `check_forbidden.py`, `check_blast_radius.py` — all pass
- [x] `pytest -q` locally (Windows, no vcan): 125 passed, 78 skipped
- [x] CI (vcan tier T3/differential, coverage ratchet) — pending; please wait for this to go green before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)