### PR TITLE
fix(ci): bound bring-up-vcan's apt-get against a stuck mirror

### DIFF
--- a/.github/actions/bring-up-vcan/action.yml
+++ b/.github/actions/bring-up-vcan/action.yml
@@ -17,8 +17,29 @@ runs:
     - name: Install and load the vcan kernel module
       shell: bash
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+        # apt-get against a stuck/congested mirror can hang indefinitely --
+        # observed multiple times as a CI run sitting here for 30-60+ minutes
+        # with no output, well past any reasonable install time. `timeout`
+        # bounds each attempt so a stuck mirror fails fast (a few minutes)
+        # instead of burning the runner for hours; retrying a few times
+        # covers a mirror that's merely slow or transiently unreachable
+        # rather than truly down. (timeout-minutes isn't valid on a
+        # composite action's own steps -- only on workflow-level steps --
+        # so the calling workflow's job-level timeout-minutes is the
+        # backstop if even these bounded retries all stall.)
+        for attempt in 1 2 3; do
+          echo "apt-get attempt $attempt/3"
+          if timeout 120 sudo apt-get update -qq \
+              && timeout 120 sudo apt-get install -y "linux-modules-extra-$(uname -r)"; then
+            break
+          fi
+          if [ "$attempt" = 3 ]; then
+            echo "::error::apt-get did not succeed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "apt-get attempt $attempt failed or timed out; retrying"
+          sleep 10
+        done
         sudo modprobe vcan
     - name: Create and bring up vcan0
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
   t2-integration:
     name: T2 · integration (vcan)
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # backstop: bring-up-vcan bounds its own apt-get retries
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -89,6 +90,7 @@ jobs:
   t3-differential:
     name: T3 · differential
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # backstop: bring-up-vcan bounds its own apt-get retries
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -110,6 +112,7 @@ jobs:
   t4-property:
     name: T4 · property/fuzz
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # backstop: bring-up-vcan bounds its own apt-get retries
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -126,6 +129,7 @@ jobs:
   coverage-ratchet:
     name: Coverage ratchet (L0-L2)
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # backstop: bring-up-vcan bounds its own apt-get retries
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
CI has hung three times in a row today (30-60+ minutes each, no output) at the exact same step: `sudo apt-get update` / `apt-get install linux-modules-extra-$(uname -r)` inside `.github/actions/bring-up-vcan`, called by every T2+ job. This is a stuck/congested package mirror on GitHub's hosted runners, unrelated to any code in this repository — every job that gets past this step passes cleanly.

- Wraps each apt-get call in `timeout 120`, retries up to 3 times with a short backoff, fails loudly with `::error::` if all three fail/time out — instead of silently hanging until the workflow's default 360-minute job timeout.
- Adds `timeout-minutes: 15` to the four jobs that call this action (`t2-integration`, `t3-differential`, `t4-property`, `coverage-ratchet`) as a backstop, since a composite action's own steps can't declare `timeout-minutes` — only the calling workflow's jobs can.

Not part of any loop's declared blast radius — this is CI infrastructure, not `src/`/`tests/`/`fixtures/`.

## Test plan
- `bash -n` syntax-checked the retry loop locally
- No fixtures, no guardrail-scoped paths touched
- Real verification is CI itself going green on this PR without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)