### PR TITLE
feat(runner): container image + quickstart smoke test (RUN-08, FW-REQ-021)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.claude
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.hypothesis
+__pycache__
+*.pyc
+DEVELOPMENT-PLAN-L0-L3-AGENTIC.pdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,23 @@ jobs:
           TAPWRIGHT_TEST_CHANNEL: vcan0
           HYPOTHESIS_PROFILE: ci
 
+  container:
+    name: Container image (RUN-08)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15 # backstop: bring-up-vcan bounds its own apt-get retries
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      # Not for a vcan0 on the runner itself -- the container creates its
+      # own, in its own network namespace -- but for the vcan kernel
+      # module, which containers share with the host and cannot load
+      # themselves (see quickstart.py's own docstring).
+      - uses: ./.github/actions/bring-up-vcan
+      - run: pip install -e ".[dev]"
+      - run: pytest tests/integration/test_container.py -v
+
   coverage-ratchet:
     name: Coverage ratchet (L0-L2)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **Container image build + quickstart smoke test** (RUN-08, `FW-REQ-021`;
+  #33): a `Dockerfile` building Tapwright from source, plus `quickstart.py`
+  — ADR-005's "zero-hardware onboarding is first-class" promise inside a
+  container: brings up a `vcan0` interface in the container's own network
+  namespace, starts a `VirtualECU`, and completes one UDS RDBI round-trip,
+  with only `--cap-add=NET_ADMIN --cap-add=NET_RAW` at `docker run` time —
+  no interactive host setup. New CI job (`container`) builds the image and
+  runs the smoke test on every push. **Scope**: build + CI smoke test only
+  in this loop — the image is not published to any registry yet, a
+  deliberate, separate, human-triggered action. Runs as root, not the
+  originally-planned non-root user: two non-root approaches (plain `USER`
+  switch, `setcap` on `ip` at build time) both failed for
+  capability-inheritance/filesystem reasons specific to this one-shot,
+  `NET_ADMIN`-requiring entrypoint — documented in the Dockerfile itself.
 - **Unified CLI** (RUN-05, `TOOL-REQ-030`, ADR-001; #31): a `tapwright`
   console-script entry point (`tapwright.runner.cli`), plus
   `python -m tapwright` via a new top-level `__main__.py` — both a thin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# RUN-08 / FW-REQ-021: a container image published alongside the PyPI
+# package, day one -- ADR-001's "one package, no separate CI build
+# artifact" property, demonstrated by `quickstart.py` at container start.
+#
+#     docker build -t tapwright .
+#     docker run --rm --cap-add=NET_ADMIN --cap-add=NET_RAW tapwright
+
+FROM python:3.10-slim
+
+# iproute2: quickstart.py's `ip link add vcan0 ...` at container start.
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir .
+
+# Runs as root -- deliberately, not an oversight. Two things were tried and
+# rejected first:
+#   1. `USER <non-root>` alone: `docker run --cap-add=NET_ADMIN` grants the
+#      capability to the container's bounding set, not to a non-root
+#      process's own inheritable/effective set at exec time -- fails with
+#      "RTNETLINK answers: Operation not permitted".
+#   2. `setcap cap_net_admin,cap_net_raw+eip` on the `ip` binary at build
+#      time, to hand the capability to that one binary regardless of UID:
+#      fails with "Invalid file 'setcap' for capability operation" -- a
+#      known Docker overlay-filesystem limitation on security.capability
+#      xattrs not persisting reliably across a build layer.
+# A privileged-entrypoint-then-drop-to-non-root wrapper (su/gosu) is the
+# standard fix for a persistent service; this is a one-shot script that
+# exits after one round-trip, not a long-running process, so that
+# machinery's cost isn't earning its keep yet -- noted as a real
+# improvement if this image grows a long-running mode later, not silently
+# dropped.
+ENTRYPOINT ["python", "quickstart.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ testpaths = ["tests"]
 markers = [
     "requires_vcan: needs a vcan interface (Linux only; skipped elsewhere)",
     "requires_hardware: needs a physical CAN interface — never runs in CI",
+    "requires_docker: needs a working docker CLI + daemon; skipped elsewhere",
 ]
 
 [tool.coverage.run]

--- a/quickstart.py
+++ b/quickstart.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""The container image's entrypoint (RUN-08, `FW-REQ-021`) — ADR-005's
+"zero-hardware onboarding is first-class" promise, demonstrated with no
+external ECU, no bench, and no host setup beyond the `--cap-add` flags
+`docker run` was given: brings up a `vcan0` interface inside the
+container's own network namespace, starts a `VirtualECU`, and completes
+one UDS ReadDataByIdentifier round-trip through it.
+
+    docker run --rm --cap-add=NET_ADMIN --cap-add=NET_RAW tapwright
+
+`vcan0` has to be created fresh here rather than at build time: a
+container's network namespace does not persist between `docker run`
+invocations, so any interface created during `docker build` would be gone
+by the time the container actually runs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any
+
+import udsoncan
+
+from tapwright.diag.uds_client import open_uds_client
+from tapwright.diag.virtual_ecu import DIDConfig, Scenario, VirtualECU
+from tapwright.hal import open_bus
+
+VCAN_CHANNEL = "vcan0"
+
+
+def bring_up_vcan(channel: str) -> None:
+    """Create and bring up `channel` inside this container's own network
+    namespace. Requires CAP_NET_ADMIN — the kernel module itself must
+    already be loaded on the *host* (a container shares the host kernel;
+    no image can carry a kernel module of its own), which is why this
+    raises an actionable message rather than a bare traceback when it
+    fails: the fix is a `docker run` flag, not something inside the image.
+    """
+    result = subprocess.run(
+        ["ip", "link", "add", "dev", channel, "type", "vcan"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"Could not create '{channel}': {result.stderr.strip()}\n\n"
+            "This container needs CAP_NET_ADMIN and CAP_NET_RAW to bring up "
+            "its own virtual CAN interface. Run with:\n\n"
+            "    docker run --cap-add=NET_ADMIN --cap-add=NET_RAW ...\n\n"
+            "(The vcan kernel module also has to be loadable on the host "
+            "kernel already -- containers share it, they cannot load their "
+            "own. On the host: sudo modprobe vcan)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    subprocess.run(["ip", "link", "set", "up", channel], check=True)
+
+
+class _RawCodec(udsoncan.DidCodec):
+    """Treats a DID's payload as opaque bytes -- udsoncan requires a codec
+    per DID before it will decode a ReadDataByIdentifier response at all.
+    Not imported from tests/: this script has to stand alone as a real
+    container entrypoint, not depend on the test tree.
+    """
+
+    def encode(self, *did_value: Any) -> bytes:
+        (value,) = did_value
+        return bytes(value)
+
+    def decode(self, did_payload: bytes) -> bytes:
+        return bytes(did_payload)
+
+    def __len__(self) -> int:
+        raise udsoncan.DidCodec.ReadAllRemainingData
+
+
+def run_quickstart(channel: str) -> None:
+    scenario = Scenario(dids={0xF190: DIDConfig(value=b"TAPWRIGHT-QUICKSTART")})
+
+    with VirtualECU(scenario, channel=channel):
+        bus = open_bus(backend="socketcan", channel=channel)
+        try:
+            client = open_uds_client(
+                bus,
+                rxid=scenario.response_id,
+                txid=scenario.request_id,
+                config={"data_identifiers": {0xF190: _RawCodec}},
+            )
+            with client:
+                response = client.read_data_by_identifier(0xF190)
+        finally:
+            bus.shutdown()
+
+    value = response.service_data.values[0xF190]
+    print(f"quickstart OK: read DID 0xF190 = {value!r} from a virtual ECU, no hardware")
+
+
+def main() -> int:
+    bring_up_vcan(VCAN_CHANNEL)
+    run_quickstart(VCAN_CHANNEL)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,7 @@ def _vcan_available() -> bool:
 def _docker_available() -> bool:
     """Is a working `docker` CLI backed by a live daemon?"""
     try:
-        result = subprocess.run(
-            ["docker", "info"], capture_output=True, text=True, timeout=10
-        )
+        result = subprocess.run(["docker", "info"], capture_output=True, text=True, timeout=10)
     except (FileNotFoundError, subprocess.SubprocessError):
         return False
     return result.returncode == 0
@@ -195,9 +193,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 item.add_marker(skip_vcan)
 
     if not _docker_available():
-        skip_docker = pytest.mark.skip(
-            reason="no working docker CLI/daemon (`docker info` failed)"
-        )
+        skip_docker = pytest.mark.skip(reason="no working docker CLI/daemon (`docker info` failed)")
         for item in items:
             if "requires_docker" in item.keywords:
                 item.add_marker(skip_docker)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,17 @@ def _vcan_available() -> bool:
     return result.returncode == 0
 
 
+def _docker_available() -> bool:
+    """Is a working `docker` CLI backed by a live daemon?"""
+    try:
+        result = subprocess.run(
+            ["docker", "info"], capture_output=True, text=True, timeout=10
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
 @pytest.fixture(scope="session")
 def vcan_channel() -> str:
     """The vcan interface tests should use."""
@@ -182,6 +193,14 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         for item in items:
             if "requires_vcan" in item.keywords:
                 item.add_marker(skip_vcan)
+
+    if not _docker_available():
+        skip_docker = pytest.mark.skip(
+            reason="no working docker CLI/daemon (`docker info` failed)"
+        )
+        for item in items:
+            if "requires_docker" in item.keywords:
+                item.add_marker(skip_docker)
 
     # Physical hardware never runs in CI: HAL-03/04/05/06 close at T3-on-vcan,
     # and a named human runs the same suite against real devices out of band,

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T2 test plan for RUN-08 — container image build + quickstart smoke test
+(`FW-REQ-021`, ADR-001).
+
+Implements #33. The oracle is the plan's own acceptance line, verbatim:
+"`docker run` executes the quickstart with no host setup." Every case below
+shells out to a real `docker` CLI against a real Docker daemon and a real
+built image — never a mock of either.
+
+## Scope notes (posted in full to #33; kept here as a pointer)
+
+- **Build + CI smoke test only.** This loop does not push the image to any
+  registry (`ghcr.io` or otherwise) — that is a deliberate, separate,
+  human-triggered action, not something this loop or its CI job does.
+- **"No host setup" reading**: `vcan`'s kernel module has to be loadable on
+  whatever machine ultimately runs `docker run` -- a host-*kernel*
+  capability no container image can carry itself (containers share the
+  host kernel). Read here as "no *interactive* host setup beyond
+  `--cap-add` flags at run time" -- the same level CI's own
+  `bring-up-vcan` action already provides at the runner level, and the
+  same constraint RemotiveBus's own approach has.
+- **Not independently tested**: the case where the host kernel genuinely
+  cannot load `vcan` at all (module absent, not just not-yet-loaded).
+  Every environment these tests actually run in (this dev machine, CI)
+  guarantees `vcan` is loadable, so there is no way to exercise "it isn't"
+  without faking the host kernel itself. Documented as a known gap, not
+  silently dropped.
+- **L2 API-cleanliness note** (test-plan skill step 5): N/A -- this loop
+  doesn't touch `diag/`'s public API surface; the quickstart script is a
+  *caller* of it, same as any other test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #33)")
+
+pytestmark = pytest.mark.requires_docker
+
+IMAGE_TAG = "tapwright:test"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_FLAGS = ["--rm", "--cap-add=NET_ADMIN", "--cap-add=NET_RAW"]
+
+
+def docker(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", *args], capture_output=True, text=True, timeout=timeout
+    )
+
+
+@pytest.fixture(scope="module")
+def built_image() -> str:
+    """Builds the image once per test module rather than per case -- a
+    `docker build` is slow, and every case in this file exercises the same
+    image, not a variant of it.
+    """
+    result = docker("build", "-t", IMAGE_TAG, str(REPO_ROOT), timeout=600)
+    assert result.returncode == 0, result.stderr
+    return IMAGE_TAG
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_image_builds_successfully(built_image):
+    result = docker("image", "inspect", built_image)
+    assert result.returncode == 0
+
+
+@SKIP
+def test_quickstart_runs_successfully_with_required_capabilities(built_image):
+    """The literal RUN-08 acceptance criterion: `docker run` executes the
+    quickstart -- vcan bring-up, a VirtualECU, one UDS RDBI round-trip --
+    end to end, with only `--cap-add` flags at run time.
+    """
+    result = docker("run", *RUN_FLAGS, built_image, timeout=60)
+
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_quickstart_can_run_twice_independently(built_image):
+    """Each `docker run` gets a fresh network namespace -- the entrypoint
+    must not assume a `vcan0` interface already exists from a prior run.
+    """
+    first = docker("run", *RUN_FLAGS, built_image, timeout=60)
+    second = docker("run", *RUN_FLAGS, built_image, timeout=60)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+
+
+@SKIP
+def test_build_context_excludes_git_and_dev_only_files(built_image):
+    """`.dockerignore` hygiene: the published image shouldn't carry this
+    repo's own `.git` history or CI-only files into a shipped artifact.
+    """
+    result = docker(
+        "run", "--rm", "--entrypoint", "sh", built_image, "-c", "test -e /app/.git"
+    )
+
+    assert result.returncode != 0  # .git must NOT be present
+
+
+@SKIP
+def test_container_runs_as_non_root_user(built_image):
+    result = docker("run", "--rm", "--entrypoint", "id", built_image, "-u")
+
+    assert result.returncode == 0
+    assert result.stdout.strip() != "0"
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_quickstart_without_required_capabilities_fails_with_actionable_error(built_image):
+    """Onboarding-quality requirement: a first-time user who forgets
+    `--cap-add` should see a clear message pointing at the missing
+    capability, not a bare Python traceback -- this is exactly the "no host
+    setup" promise's most likely first failure mode.
+    """
+    result = docker("run", "--rm", built_image, timeout=60)
+
+    assert result.returncode != 0
+    assert "cap-add" in result.stderr.lower() or "net_admin" in result.stderr.lower()

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -26,6 +26,15 @@ built image — never a mock of either.
   guarantees `vcan` is loadable, so there is no way to exercise "it isn't"
   without faking the host kernel itself. Documented as a known gap, not
   silently dropped.
+- **Scope correction found during tdd-develop, posted to #33**: the
+  container runs as root, not the non-root user originally planned. Two
+  non-root approaches were tried and both failed for reasons specific to
+  this one-shot, `NET_ADMIN`-requiring entrypoint (capability inheritance
+  doesn't cross a plain `USER` switch; `setcap` at build time hit a Docker
+  overlay-filesystem limitation) -- see the Dockerfile's own comment. The
+  corresponding test now asserts the actual (root) behavior rather than
+  silently dropping the hygiene concern, so a future change away from root
+  has to update this test deliberately.
 - **L2 API-cleanliness note** (test-plan skill step 5): N/A -- this loop
   doesn't touch `diag/`'s public API surface; the quickstart script is a
   *caller* of it, same as any other test.
@@ -48,8 +57,18 @@ RUN_FLAGS = ["--rm", "--cap-add=NET_ADMIN", "--cap-add=NET_RAW"]
 
 
 def docker(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    # Docker's build/run output is UTF-8 regardless of platform; the default
+    # `text=True` encoding follows the OS locale, which on Windows is a
+    # legacy codepage (cp1252) that can't decode it -- observed as a
+    # background-thread UnicodeDecodeError from subprocess's own output
+    # reader, surfacing as a pytest warning rather than a clean failure.
     return subprocess.run(
-        ["docker", *args], capture_output=True, text=True, timeout=timeout
+        ["docker", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
     )
 
 
@@ -69,13 +88,11 @@ def built_image() -> str:
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_image_builds_successfully(built_image):
     result = docker("image", "inspect", built_image)
     assert result.returncode == 0
 
 
-@SKIP
 def test_quickstart_runs_successfully_with_required_capabilities(built_image):
     """The literal RUN-08 acceptance criterion: `docker run` executes the
     quickstart -- vcan bring-up, a VirtualECU, one UDS RDBI round-trip --
@@ -91,7 +108,6 @@ def test_quickstart_runs_successfully_with_required_capabilities(built_image):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_quickstart_can_run_twice_independently(built_image):
     """Each `docker run` gets a fresh network namespace -- the entrypoint
     must not assume a `vcan0` interface already exists from a prior run.
@@ -103,24 +119,31 @@ def test_quickstart_can_run_twice_independently(built_image):
     assert second.returncode == 0, second.stderr
 
 
-@SKIP
 def test_build_context_excludes_git_and_dev_only_files(built_image):
     """`.dockerignore` hygiene: the published image shouldn't carry this
     repo's own `.git` history or CI-only files into a shipped artifact.
     """
-    result = docker(
-        "run", "--rm", "--entrypoint", "sh", built_image, "-c", "test -e /app/.git"
-    )
+    result = docker("run", "--rm", "--entrypoint", "sh", built_image, "-c", "test -e /app/.git")
 
     assert result.returncode != 0  # .git must NOT be present
 
 
-@SKIP
-def test_container_runs_as_non_root_user(built_image):
+def test_container_runs_as_root_deliberately_not_by_default_omission(built_image):
+    """Scope correction, made during tdd-develop and posted to #33: this was
+    originally a non-root check. Two non-root approaches were tried and
+    both failed for filesystem/capability-inheritance reasons specific to
+    this one-shot, `NET_ADMIN`-requiring entrypoint (see the Dockerfile's
+    own comment for what was tried). Rather than silently dropping the
+    hygiene concern, this case asserts the *actual* current behavior --
+    root -- so a future change away from root (e.g. if this image grows a
+    long-running mode where the su/gosu wrapper's cost is worth it) fails
+    this test and has to update it deliberately, instead of the image
+    quietly drifting to non-root with no test noticing either way.
+    """
     result = docker("run", "--rm", "--entrypoint", "id", built_image, "-u")
 
     assert result.returncode == 0
-    assert result.stdout.strip() != "0"
+    assert result.stdout.strip() == "0"
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +151,6 @@ def test_container_runs_as_non_root_user(built_image):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_quickstart_without_required_capabilities_fails_with_actionable_error(built_image):
     """Onboarding-quality requirement: a first-time user who forgets
     `--cap-add` should see a clear message pointing at the missing


### PR DESCRIPTION
## What this changes and why
Closes #33

FW-REQ-021 / ADR-001: a container image published alongside the PyPI package, day one — "one package, no separate CI build artifact." Adds:
- `Dockerfile`: builds Tapwright from this repo's source (not PyPI — not published there yet).
- `quickstart.py`: the container's entrypoint, and the first formal "quickstart" defined anywhere in this repo — brings up `vcan0` inside the container's own network namespace, starts a `VirtualECU`, completes one UDS ReadDataByIdentifier round-trip. ADR-005's zero-hardware promise, demonstrated inside a container.
- A new `container` CI job builds the image and runs the smoke test on every push.

**Scope, as agreed before implementation**: build + CI smoke test only. This does **not** push the image to any registry (`ghcr.io` or otherwise) — that's a deliberate, separate, human-triggered action.

**Two things tdd-develop surfaced and corrected in place** (also posted to #33):
1. **Non-root scope correction.** Originally planned a non-root container user. Two approaches failed for real, verifiable reasons: a plain `USER` switch doesn't carry `--cap-add`'s capabilities across the UID change (`Operation not permitted`), and `setcap` on the `ip` binary at build time hits a Docker overlay-filesystem limitation on persisting `security.capability` xattrs. The image runs as root, deliberately, for this one-shot entrypoint — documented in the Dockerfile, with the test asserting the actual behavior instead of silently dropping the hygiene concern.
2. **A real bug in the test helper**: `subprocess.run(text=True)` on Windows decodes with the OS locale codepage (cp1252), which can't handle Docker's UTF-8 output — fixed with explicit `encoding="utf-8", errors="replace"`.

## Type of change
- [x] New feature

## How this was tested
- `tests/integration/test_container.py`: 6 cases, every one shells out to a real `docker` CLI against a real daemon and a real built image (new `requires_docker` marker + skip logic, mirroring `requires_vcan`'s existing pattern)
- **Locally verified (Windows + Docker Desktop)**: 4/6 — image builds, `.dockerignore` excludes `.git`, container runs as root (by design, asserted), missing `--cap-add` fails with an actionable error message
- **CI-only**: 2/6 — the quickstart actually completing its vcan round-trip, and running twice independently. Docker Desktop's own Linux VM on this dev machine has no `vcan` kernel module (a documented, known gap); CI's Linux runners share the host kernel directly with their containers, which is what actually validates these
- `ruff check .` / `ruff format --check .` — clean
- `mypy src quickstart.py` — clean
- `pytest --cov=tapwright --cov-report=term-missing` — 137 passed, 78 skipped, 2 failed locally (the CI-only cases above, expected)
- `tools/check_spdx.py`, `check_forbidden.py`, `check_licences.py`, `check_fixtures.py`, `check_blast_radius.py` — all pass

## Checklist
- [x] DCO sign-off on all commits
- [x] Tests added (test plan committed separately at a57dfcc, implemented here)
- [x] CHANGELOG.md updated
- [x] Lint/format/type-check clean
- [x] Doesn't touch `diag/`'s public API — `docs/architecture.md` §4 re-read not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)