### PR TITLE
feat(runner): HTML report via pytest-html (RUN-03, TOOL-REQ-031)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ env/
 htmlcov/
 coverage.xml
 
+# RUN-03: auto-generated HTML test report (tapwright.runner.plugin's
+# pytest_configure default) -- a build artifact, not something to commit.
+tapwright-report.html
+
 # Editors / OS
 .vscode/
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **HTML report** (RUN-03, `TOOL-REQ-031`; #39): a self-contained,
+  auto-generated HTML report (pass/fail, timing) after every test run —
+  wraps `pytest-html` (new dependency, MPL-2.0) rather than reimplementing
+  report rendering; `tapwright.runner.plugin` sets a default `--html` path
+  only if the user hasn't already chosen one, so a report appears with
+  zero required flags, matching TOOL-REQ-031's "without additional
+  configuration" wording literally. "Decoded frames" isn't in the report
+  yet — no mechanism anywhere in the codebase records which frames a test
+  exchanged for a report to read back, flagged as a real follow-up rather
+  than silently dropped.
 - **ARXML ingestion + symbolic decode via `cantools`** (BUS-02,
   `TOOL-REQ-015`; #37): `tapwright.dbc_arxml.load_arxml()`, sharing
   `load_dbc()`'s wrapper class — renamed `DbcDatabase` → `CanDatabase`

--- a/licences.toml
+++ b/licences.toml
@@ -156,3 +156,10 @@ name = "tomli"
 licence = "MIT"
 verified = "2026-08-14"
 role = "TOML parsing on Python 3.10, where tomllib is unavailable (dev only)"
+
+[[dependency]]
+name = "pytest-html"
+licence = "MPL-2.0"
+verified = "2026-08-25"
+role = "RUN-03: HTML report generation, wrapped rather than reimplemented"
+notes = "MPL-2.0 is file-level copyleft; used as an unmodified PyPI dependency, never vendored. Pulls in pytest-metadata (also MPL-2.0, transitive, not separately declared in pyproject.toml so not separately entered here)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "udsoncan>=1.26",
     "doipclient>=1.1",
     "cantools>=42",  # fixtures/expected/*.json were derived against 42.0.3
+    "pytest-html>=4.2",  # RUN-03: HTML report, wraps rather than reimplements
 ]
 
 [project.optional-dependencies]

--- a/src/tapwright/runner/plugin.py
+++ b/src/tapwright/runner/plugin.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """The `pytest11` plugin: `ecu`, `bus`, `uds` fixtures (RUN-01,
-`TOOL-REQ-028`).
+`TOOL-REQ-028`) and an auto-enabled HTML report (RUN-03, `TOOL-REQ-031`).
 
 Registered via `pyproject.toml`'s `[project.entry-points.pytest11]` — pytest
 auto-discovers this on `pip install tapwright`, so a user's own test file
@@ -39,6 +39,26 @@ from tapwright.diag.virtual_ecu import Scenario, VirtualECU
 from tapwright.hal import Bus, open_bus
 
 DEFAULT_CHANNEL = "vcan0"
+DEFAULT_HTML_REPORT_PATH = "tapwright-report.html"
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """Auto-enables `pytest-html`'s report with zero required flags —
+    `TOOL-REQ-031`'s "without additional configuration" — by setting its
+    `htmlpath` option before `pytest-html`'s own `pytest_configure` reads
+    it (that's what `tryfirst=True` is for: `pytest-html`'s reporter only
+    registers if `htmlpath` is already truthy by the time its hook runs).
+
+    Only fills the gap: an explicit `--html=...` from the user is never
+    overridden, and if `pytest-html` isn't installed for some reason this
+    is a silent no-op rather than a hard dependency failure at collection
+    time (`hasplugin` returning `False` on a fresh entry-point rescan is
+    the only realistic way that happens, since it's a declared dependency).
+    """
+    if config.pluginmanager.hasplugin("html") and not config.getoption("htmlpath", None):
+        config.option.htmlpath = DEFAULT_HTML_REPORT_PATH
+        config.option.self_contained_html = True
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/integration/test_html_report.py
+++ b/tests/integration/test_html_report.py
@@ -49,10 +49,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #39)")
-
 PASSING_TEST = "def test_ok():\n    assert True\n"
 FAILING_TEST = "def test_not_ok():\n    assert False\n"
 MIXED_SUITE = (
@@ -81,7 +77,6 @@ def run_pytest(*args: str, cwd: Path) -> subprocess.CompletedProcess:
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_report_auto_generates_with_no_explicit_flag(tmp_path):
     """The literal "without additional configuration" requirement: no
     `--html=...` flag passed, a report still appears.
@@ -94,7 +89,6 @@ def test_report_auto_generates_with_no_explicit_flag(tmp_path):
     assert len(reports) == 1
 
 
-@SKIP
 def test_report_contains_every_result(tmp_path):
     (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
 
@@ -111,7 +105,6 @@ def test_report_contains_every_result(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_explicit_html_flag_is_not_overridden(tmp_path):
     """A user who already knows what they're doing and passes their own
     `--html=` path keeps it -- the auto-default only fills a gap, it
@@ -123,35 +116,43 @@ def test_explicit_html_flag_is_not_overridden(tmp_path):
     run_pytest("test_sample.py", f"--html={custom_path}", cwd=tmp_path)
 
     assert custom_path.exists()
-    assert not any(
-        p.name != "custom_report.html" for p in tmp_path.glob("*.html")
-    )
+    assert not any(p.name != "custom_report.html" for p in tmp_path.glob("*.html"))
 
 
-@SKIP
 def test_repeated_runs_produce_the_same_results_table(tmp_path):
     """The testable half of "deterministic": the same suite run twice
-    produces the same set of results, same order, same outcomes -- not
-    byte-identical files (see module docstring for why that's out of
-    scope: the default template embeds a generation timestamp).
+    produces the same set of results, same order, same outcomes.
+
+    Not byte-identical files -- confirmed directly while writing this
+    test: `pytest-html`'s report embeds a generation timestamp *and* a
+    wall-clock duration per test and for the whole run, both of which
+    legitimately vary run to run (duration is required content --
+    `TOOL-REQ-031` names "timing" as part of the report -- so this isn't a
+    gap to close, it's an inherent property of a report that includes
+    timing at all). What's extracted and compared instead is just
+    `(testId, result)` pairs, in order -- the part that would actually
+    catch a real bug, e.g. a race in how results get collected or reported
+    out of order.
     """
-    (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
+    run1_dir = tmp_path / "run1"
+    run2_dir = tmp_path / "run2"
+    run1_dir.mkdir()
+    run2_dir.mkdir()
+    (run1_dir / "test_sample.py").write_text(MIXED_SUITE)
+    (run2_dir / "test_sample.py").write_text(MIXED_SUITE)
 
-    run_pytest("test_sample.py", "--html=r1.html", cwd=tmp_path)
-    run_pytest("test_sample.py", "--html=r2.html", cwd=tmp_path)
+    run_pytest("test_sample.py", "--html=report.html", cwd=run1_dir)
+    run_pytest("test_sample.py", "--html=report.html", cwd=run2_dir)
 
-    def results_only(report_path: Path) -> str:
-        # Strip anything timestamp-shaped so this compares the meaningful
-        # content, not the one deliberately-excluded piece of non-determinism.
+    def outcomes(report_path: Path) -> list[tuple[str, str]]:
         import re
 
         text = report_path.read_text(encoding="utf-8")
-        return re.sub(r"Report generated on .*? by", "", text)
+        return re.findall(r'"result":\s*"([^"]+)",\s*"testId":\s*"([^"]+)"', text)
 
-    assert results_only(tmp_path / "r1.html") == results_only(tmp_path / "r2.html")
+    assert outcomes(run1_dir / "report.html") == outcomes(run2_dir / "report.html")
 
 
-@SKIP
 def test_empty_suite_still_produces_a_valid_report(tmp_path):
     run_pytest(cwd=tmp_path)  # empty directory, nothing to collect
 
@@ -165,7 +166,6 @@ def test_empty_suite_still_produces_a_valid_report(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_failed_test_is_clearly_marked_failed_in_the_report(tmp_path):
     (tmp_path / "test_sample.py").write_text(FAILING_TEST)
 
@@ -176,7 +176,6 @@ def test_failed_test_is_clearly_marked_failed_in_the_report(tmp_path):
     assert "failed" in report.lower()
 
 
-@SKIP
 def test_skipped_test_still_appears_not_silently_dropped(tmp_path):
     (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
 

--- a/tests/integration/test_html_report.py
+++ b/tests/integration/test_html_report.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T2 test plan for RUN-03 — HTML report (`TOOL-REQ-031`).
+
+Implements #39. Oracle is the plan's own line: "Report renders; contains
+every result; deterministic output." Every case spawns a genuine
+subprocess `pytest` run against a small throwaway suite and inspects the
+resulting HTML file -- testing "the report auto-generates when tapwright's
+plugin is active" from *within* the same pytest process being tested would
+be circular; a separate process is the only way to observe it honestly.
+
+## Reuse decision (`AGENTS.md` §3)
+
+Wraps `pytest-html` (MPL-2.0, already on `licences.toml`'s `allowed` list,
+no isolation required) rather than writing HTML report generation from
+scratch -- it already solves "renders, contains every result, self-
+contained file" cleanly; per `pytest-html`'s own `pytest_addoption()`,
+`--html=<path>` is its only required option and `--self-contained-html`
+folds every asset into one file, matching "no additional configuration."
+`tapwright.runner.plugin` gains a `pytest_configure()` hook that sets
+`config.option.htmlpath` to a default path *only if the user hasn't
+already set one* -- `pytest-html` still does the actual rendering,
+`tapwright` only makes the option automatic. New dependencies:
+`pytest-html` and its own transitive `pytest-metadata` dependency, both
+MPL-2.0 -- to be added to `pyproject.toml` and `licences.toml`.
+
+## Scope notes (posted in full to #39; kept here as a pointer)
+
+- **"Decoded frames" is a documented gap, not built here.** No mechanism
+  anywhere in this codebase records which frames a test exchanged during
+  its run for a report to read back later -- flagged as a real follow-up
+  in the issue, not silently dropped or speculatively built.
+- **"Deterministic output" scoped to the results table, not the raw
+  bytes.** `pytest-html`'s own default template embeds a wall-clock
+  generation timestamp ("Report generated on <date> at <time>") --
+  confirmed directly by generating one during this test plan's own
+  research. No report-generation tool produces byte-identical files
+  across time and that isn't really what "deterministic" means in this
+  context (see `NFR-003`, which is about flaky *test outcomes*, not
+  byte-identical *files*). What's tested here: the same suite run twice
+  produces the same set of results, in the same order, with the same
+  outcomes -- the part that would actually catch a real bug (e.g. a race
+  in how results get collected).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #39)")
+
+PASSING_TEST = "def test_ok():\n    assert True\n"
+FAILING_TEST = "def test_not_ok():\n    assert False\n"
+MIXED_SUITE = (
+    "import pytest\n"
+    "def test_a():\n    assert True\n"
+    "def test_b():\n    assert False\n"
+    '@pytest.mark.skip(reason="demo")\n'
+    "def test_c():\n    assert True\n"
+)
+
+
+def run_pytest(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_report_auto_generates_with_no_explicit_flag(tmp_path):
+    """The literal "without additional configuration" requirement: no
+    `--html=...` flag passed, a report still appears.
+    """
+    (tmp_path / "test_sample.py").write_text(PASSING_TEST)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    reports = list(tmp_path.glob("*.html"))
+    assert len(reports) == 1
+
+
+@SKIP
+def test_report_contains_every_result(tmp_path):
+    (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report = next(tmp_path.glob("*.html")).read_text(encoding="utf-8")
+    assert "test_a" in report
+    assert "test_b" in report
+    assert "test_c" in report
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_explicit_html_flag_is_not_overridden(tmp_path):
+    """A user who already knows what they're doing and passes their own
+    `--html=` path keeps it -- the auto-default only fills a gap, it
+    doesn't fight an explicit choice.
+    """
+    (tmp_path / "test_sample.py").write_text(PASSING_TEST)
+    custom_path = tmp_path / "custom_report.html"
+
+    run_pytest("test_sample.py", f"--html={custom_path}", cwd=tmp_path)
+
+    assert custom_path.exists()
+    assert not any(
+        p.name != "custom_report.html" for p in tmp_path.glob("*.html")
+    )
+
+
+@SKIP
+def test_repeated_runs_produce_the_same_results_table(tmp_path):
+    """The testable half of "deterministic": the same suite run twice
+    produces the same set of results, same order, same outcomes -- not
+    byte-identical files (see module docstring for why that's out of
+    scope: the default template embeds a generation timestamp).
+    """
+    (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
+
+    run_pytest("test_sample.py", "--html=r1.html", cwd=tmp_path)
+    run_pytest("test_sample.py", "--html=r2.html", cwd=tmp_path)
+
+    def results_only(report_path: Path) -> str:
+        # Strip anything timestamp-shaped so this compares the meaningful
+        # content, not the one deliberately-excluded piece of non-determinism.
+        import re
+
+        text = report_path.read_text(encoding="utf-8")
+        return re.sub(r"Report generated on .*? by", "", text)
+
+    assert results_only(tmp_path / "r1.html") == results_only(tmp_path / "r2.html")
+
+
+@SKIP
+def test_empty_suite_still_produces_a_valid_report(tmp_path):
+    run_pytest(cwd=tmp_path)  # empty directory, nothing to collect
+
+    reports = list(tmp_path.glob("*.html"))
+    assert len(reports) == 1
+    assert "<html" in reports[0].read_text(encoding="utf-8").lower()
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_failed_test_is_clearly_marked_failed_in_the_report(tmp_path):
+    (tmp_path / "test_sample.py").write_text(FAILING_TEST)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report = next(tmp_path.glob("*.html")).read_text(encoding="utf-8")
+    assert "test_not_ok" in report
+    assert "failed" in report.lower()
+
+
+@SKIP
+def test_skipped_test_still_appears_not_silently_dropped(tmp_path):
+    (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report = next(tmp_path.glob("*.html")).read_text(encoding="utf-8")
+    assert "test_c" in report
+    assert "skipped" in report.lower()


### PR DESCRIPTION
## What this changes and why
Closes #39

Implements `TOOL-REQ-031`: "A completed test run produces a human-readable HTML report without additional configuration." Wraps `pytest-html` (MPL-2.0, new dependency) rather than reimplementing report rendering — `tapwright.runner.plugin` gains a `tryfirst` `pytest_configure` hook that sets a default `--html` path only if the user hasn't already chosen one. `pytest-html` still does all the actual rendering; `tryfirst=True` matters because its own `pytest_configure` only registers its reporter if `htmlpath` is already truthy by the time its hook runs.

**Scope, as agreed before implementation**: "decoded frames" isn't in the report yet — no mechanism anywhere in the codebase records which frames a test exchanged during its run for a report to read back later. Flagged as a real follow-up in the issue, not silently dropped or speculatively built.

## Type of change
- [x] New feature

## How this was tested
- `tests/integration/test_html_report.py`: 7 cases, every one spawns a genuine subprocess `pytest` run against a throwaway suite and inspects the resulting HTML file — happy path (auto-generates with no flag, contains every result), edge cases (explicit `--html=` not overridden, repeated runs produce the same results, empty suite still valid), error cases (failed/skipped tests clearly marked, not silently dropped)
- One genuine test-design fix found via TDD, not a product bug: the "repeated runs produce the same results" case needed to compare `(testId, result)` pairs specifically rather than raw report text, since `pytest-html` legitimately embeds per-test timing that varies run to run — required content (`TOOL-REQ-031` names "timing"), not a determinism gap to close
- `ruff check .` / `ruff format --check .` — clean
- `mypy src` — clean
- `pytest --cov=tapwright --cov-report=term-missing` — 158 passed, 86 skipped, 2 pre-existing failures (RUN-08's documented Docker-Desktop-VM vcan gap, unrelated to this change)
- `tools/check_spdx.py`, `check_forbidden.py`, `check_licences.py` (14 dependencies now, `pytest-html` verified MPL-2.0/allowed), `check_fixtures.py`, `check_blast_radius.py` — all pass

## Checklist
- [x] DCO sign-off on all commits
- [x] Tests added (test plan committed separately at 3d0b23c, implemented here)
- [x] CHANGELOG.md updated
- [x] Lint/format/type-check clean
- [x] Doesn't touch `diag/`'s public API — `docs/architecture.md` §4 re-read not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)