### PR TITLE
feat(runner): JSON report via pytest-json-report (RUN-04, TOOL-REQ-032)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,10 @@ env/
 htmlcov/
 coverage.xml
 
-# RUN-03: auto-generated HTML test report (tapwright.runner.plugin's
-# pytest_configure default) -- a build artifact, not something to commit.
+# RUN-03/RUN-04: auto-generated test reports (tapwright.runner.plugin's
+# pytest_configure defaults) -- build artifacts, not something to commit.
 tapwright-report.html
+tapwright-report.json
 
 # Editors / OS
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **JSON machine-readable report** (RUN-04, `TOOL-REQ-032`; #41): an
+  auto-generated JSON report after every test run — wraps
+  `pytest-json-report` (new dependency, MIT) via the same
+  auto-enable-with-zero-flags `pytest_configure` hook RUN-03 added, rather
+  than reimplementing report generation. Validates against a new schema
+  this loop defines and ships (`docs/schemas/run-report.schema.json`) —
+  deliberately a subset of the underlying library's own output, and
+  deliberately not the full ASAM ATX standard `TOOL-REQ-032`'s title
+  mentions, since the requirement's own wording rules that out for now
+  ("not built now, just don't block it"). Priority filed as Should,
+  matching `TOOL-REQ-032`'s own MoSCoW rating (the plan's loop table said
+  Must — a discrepancy flagged rather than silently picked).
 - **HTML report** (RUN-03, `TOOL-REQ-031`; #39): a self-contained,
   auto-generated HTML report (pass/fail, timing) after every test run —
   wraps `pytest-html` (new dependency, MPL-2.0) rather than reimplementing

--- a/docs/schemas/run-report.schema.json
+++ b/docs/schemas/run-report.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/SKIFIN-IT-SERVICES/tapwright/docs/schemas/run-report.schema.json",
+  "title": "Tapwright test run report (RUN-04, TOOL-REQ-032)",
+  "description": "The contract tapwright's JSON report promises a results-warehouse consumer -- deliberately a subset of whatever the underlying pytest-json-report plugin happens to emit, not a full mirror of it, so this schema (and this loop's own claim of 'schema-validates') stays true even if the wrapped library adds fields later.",
+  "type": "object",
+  "required": ["summary", "tests"],
+  "properties": {
+    "summary": {
+      "type": "object",
+      "description": "Per-outcome counts for the run.",
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["total"]
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["nodeid", "outcome"],
+        "properties": {
+          "nodeid": {
+            "type": "string",
+            "description": "The pytest node ID, e.g. 'tests/test_x.py::test_y'."
+          },
+          "outcome": {
+            "type": "string",
+            "enum": ["passed", "failed", "skipped", "error"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/licences.toml
+++ b/licences.toml
@@ -163,3 +163,15 @@ licence = "MPL-2.0"
 verified = "2026-08-25"
 role = "RUN-03: HTML report generation, wrapped rather than reimplemented"
 notes = "MPL-2.0 is file-level copyleft; used as an unmodified PyPI dependency, never vendored. Pulls in pytest-metadata (also MPL-2.0, transitive, not separately declared in pyproject.toml so not separately entered here)."
+
+[[dependency]]
+name = "pytest-json-report"
+licence = "MIT"
+verified = "2026-08-25"
+role = "RUN-04: JSON report generation, wrapped rather than reimplemented"
+
+[[dependency]]
+name = "jsonschema"
+licence = "MIT"
+verified = "2026-08-25"
+role = "RUN-04's own test suite: validates the JSON report against docs/schemas/run-report.schema.json (dev only)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "doipclient>=1.1",
     "cantools>=42",  # fixtures/expected/*.json were derived against 42.0.3
     "pytest-html>=4.2",  # RUN-03: HTML report, wraps rather than reimplements
+    "pytest-json-report>=1.5",  # RUN-04: JSON report, wraps rather than reimplements
 ]
 
 [project.optional-dependencies]
@@ -61,6 +62,7 @@ dev = [
     "pytest>=8",
     "pytest-cov",
     "hypothesis>=6",          # T4 property/fuzz tier
+    "jsonschema>=4",          # RUN-04's own test suite: schema validation
     "ruff",
     "mypy",
     "pre-commit",

--- a/src/tapwright/runner/plugin.py
+++ b/src/tapwright/runner/plugin.py
@@ -40,25 +40,47 @@ from tapwright.hal import Bus, open_bus
 
 DEFAULT_CHANNEL = "vcan0"
 DEFAULT_HTML_REPORT_PATH = "tapwright-report.html"
+DEFAULT_JSON_REPORT_PATH = "tapwright-report.json"
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config: pytest.Config) -> None:
-    """Auto-enables `pytest-html`'s report with zero required flags —
-    `TOOL-REQ-031`'s "without additional configuration" — by setting its
-    `htmlpath` option before `pytest-html`'s own `pytest_configure` reads
-    it (that's what `tryfirst=True` is for: `pytest-html`'s reporter only
-    registers if `htmlpath` is already truthy by the time its hook runs).
+    """Auto-enables `pytest-html`'s (RUN-03, `TOOL-REQ-031`) and
+    `pytest-json-report`'s (RUN-04, `TOOL-REQ-032`) reports with zero
+    required flags — both requirements' "without additional configuration"
+    / "not built now, just don't block it" wording — by setting each
+    plugin's own option before its `pytest_configure` reads it (that's
+    what `tryfirst=True` is for: both plugins' reporters only register if
+    their option is already truthy by the time their own hook runs).
 
-    Only fills the gap: an explicit `--html=...` from the user is never
-    overridden, and if `pytest-html` isn't installed for some reason this
-    is a silent no-op rather than a hard dependency failure at collection
-    time (`hasplugin` returning `False` on a fresh entry-point rescan is
-    the only realistic way that happens, since it's a declared dependency).
+    Each only fills its gap: an explicit `--html=...`/`--json-report...`
+    from the user is never overridden, and if a plugin isn't installed for
+    some reason this is a silent no-op rather than a hard dependency
+    failure at collection time (`hasplugin` returning `False` on a fresh
+    entry-point rescan is the only realistic way that happens, since both
+    are declared dependencies).
     """
     if config.pluginmanager.hasplugin("html") and not config.getoption("htmlpath", None):
         config.option.htmlpath = DEFAULT_HTML_REPORT_PATH
         config.option.self_contained_html = True
+
+    if config.pluginmanager.hasplugin("pytest_jsonreport"):
+        # Unlike pytest-html's single `htmlpath` option, pytest-json-report
+        # splits "enabled" (--json-report, a bool) from "where"
+        # (--json-report-file, its own default ".report.json") into two
+        # options -- found directly while writing this loop's own test:
+        # a user passing only --json-report-file, without --json-report,
+        # is clearly choosing a path and expects a report there, but
+        # naively only checking the bool would both fail to honor that
+        # path AND overwrite it with our own default.
+        user_chose_path = config.getoption("json_report_file", None) not in (
+            None,
+            ".report.json",
+        )
+        if not config.getoption("json_report", False):
+            config.option.json_report = True
+            if not user_chose_path:
+                config.option.json_report_file = DEFAULT_JSON_REPORT_PATH
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/integration/test_json_report.py
+++ b/tests/integration/test_json_report.py
@@ -49,10 +49,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #41)")
-
 PASSING_TEST = "def test_ok():\n    assert True\n"
 FAILING_TEST = "def test_not_ok():\n    assert False\n"
 MIXED_SUITE = (
@@ -63,9 +59,7 @@ MIXED_SUITE = (
     "def test_c():\n    assert True\n"
 )
 
-SCHEMA_PATH = (
-    Path(__file__).resolve().parents[2] / "docs" / "schemas" / "run-report.schema.json"
-)
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "schemas" / "run-report.schema.json"
 
 
 def run_pytest(*args: str, cwd: Path) -> subprocess.CompletedProcess:
@@ -85,7 +79,6 @@ def run_pytest(*args: str, cwd: Path) -> subprocess.CompletedProcess:
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_report_auto_generates_with_no_explicit_flag(tmp_path):
     (tmp_path / "test_sample.py").write_text(PASSING_TEST)
 
@@ -95,7 +88,6 @@ def test_report_auto_generates_with_no_explicit_flag(tmp_path):
     assert len(reports) == 1
 
 
-@SKIP
 def test_report_contains_every_result(tmp_path):
     (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
 
@@ -115,7 +107,6 @@ def test_report_contains_every_result(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_explicit_json_report_file_is_not_overridden(tmp_path):
     (tmp_path / "test_sample.py").write_text(PASSING_TEST)
     custom_path = tmp_path / "custom_report.json"
@@ -126,7 +117,6 @@ def test_explicit_json_report_file_is_not_overridden(tmp_path):
     assert not any(p.name != "custom_report.json" for p in tmp_path.glob("*.json"))
 
 
-@SKIP
 def test_report_round_trips_through_json(tmp_path):
     """The literal "round-trips" requirement: parse, re-serialize,
     re-parse, same data survives.
@@ -141,9 +131,8 @@ def test_report_round_trips_through_json(tmp_path):
     assert first == second
 
 
-@SKIP
 def test_report_validates_against_our_schema(tmp_path):
-    """"Schema-validates" against `docs/schemas/run-report.schema.json` —
+    """ "Schema-validates" against `docs/schemas/run-report.schema.json` —
     the schema this loop defines and ships, not an external ATX spec (see
     module docstring).
     """
@@ -163,7 +152,6 @@ def test_report_validates_against_our_schema(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_failed_test_has_failed_outcome_in_the_report(tmp_path):
     (tmp_path / "test_sample.py").write_text(FAILING_TEST)
 
@@ -175,7 +163,6 @@ def test_failed_test_has_failed_outcome_in_the_report(tmp_path):
     assert test["outcome"] == "failed"
 
 
-@SKIP
 def test_skipped_test_has_skipped_outcome_not_silently_dropped(tmp_path):
     (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
 

--- a/tests/integration/test_json_report.py
+++ b/tests/integration/test_json_report.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T2 test plan for RUN-04 — JSON machine-readable report (`TOOL-REQ-032`).
+
+Implements #41. Oracle is the plan's own line: "Schema-validates;
+round-trips." Every case spawns a genuine subprocess `pytest` run against
+a throwaway suite and inspects the resulting JSON file — same reasoning as
+RUN-03's own test file: testing "the report auto-generates when
+tapwright's plugin is active" from within the same pytest process being
+tested would be circular.
+
+## Priority + scope correction (posted in full to #41; kept here as a
+pointer)
+
+- **Priority is Should, not Must** — the plan's own loop table said "Must"
+  but `TOOL-REQ-032` itself, the requirement this loop implements, rates
+  itself "Should." Filed and treated as Should.
+- **"Schema-validates" means against a schema this loop defines and
+  ships** (`docs/schemas/run-report.schema.json`), not an external ASAM
+  ATX standard — `TOOL-REQ-032`'s own wording ("not built now, just don't
+  block it") rules out a full ATX implementation here. The schema codifies
+  what `tapwright` promises a results-warehouse consumer, not everything
+  the underlying library happens to emit.
+
+## Reuse decision (`AGENTS.md` §3)
+
+Wraps `pytest-json-report` (MIT, already allowed) rather than writing JSON
+report generation from scratch — same reuse-first approach RUN-03 took
+with `pytest-html`. `tapwright.runner.plugin`'s existing `pytest_configure`
+hook (already `tryfirst=True` for the HTML report) gains the same
+auto-enable logic for `--json-report`: only fills the gap if the user
+hasn't already opted in, and `pytest-json-report`'s own `pytest_configure`
+only registers its reporter if `config.option.json_report` is already
+truthy by the time its hook runs (confirmed directly by reading its
+source) — the same ordering requirement `tryfirst=True` already satisfies
+for the HTML case, so this reuses the existing hook rather than adding a
+second one.
+
+`jsonschema` (MIT) is a new **dev**-only dependency — schema validation is
+this loop's own test-suite property, not something the runtime
+report-writing path re-validates on every run (that would just be
+`pytest-json-report` checking its own already-correct output).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #41)")
+
+PASSING_TEST = "def test_ok():\n    assert True\n"
+FAILING_TEST = "def test_not_ok():\n    assert False\n"
+MIXED_SUITE = (
+    "import pytest\n"
+    "def test_a():\n    assert True\n"
+    "def test_b():\n    assert False\n"
+    '@pytest.mark.skip(reason="demo")\n'
+    "def test_c():\n    assert True\n"
+)
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "schemas" / "run-report.schema.json"
+)
+
+
+def run_pytest(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_report_auto_generates_with_no_explicit_flag(tmp_path):
+    (tmp_path / "test_sample.py").write_text(PASSING_TEST)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    reports = list(tmp_path.glob("*.json"))
+    assert len(reports) == 1
+
+
+@SKIP
+def test_report_contains_every_result(tmp_path):
+    (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+    node_ids = {test["nodeid"] for test in report["tests"]}
+    assert node_ids == {
+        "test_sample.py::test_a",
+        "test_sample.py::test_b",
+        "test_sample.py::test_c",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_explicit_json_report_file_is_not_overridden(tmp_path):
+    (tmp_path / "test_sample.py").write_text(PASSING_TEST)
+    custom_path = tmp_path / "custom_report.json"
+
+    run_pytest("test_sample.py", f"--json-report-file={custom_path}", cwd=tmp_path)
+
+    assert custom_path.exists()
+    assert not any(p.name != "custom_report.json" for p in tmp_path.glob("*.json"))
+
+
+@SKIP
+def test_report_round_trips_through_json(tmp_path):
+    """The literal "round-trips" requirement: parse, re-serialize,
+    re-parse, same data survives.
+    """
+    (tmp_path / "test_sample.py").write_text(PASSING_TEST)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report_path = next(tmp_path.glob("*.json"))
+    first = json.loads(report_path.read_text(encoding="utf-8"))
+    second = json.loads(json.dumps(first))
+    assert first == second
+
+
+@SKIP
+def test_report_validates_against_our_schema(tmp_path):
+    """"Schema-validates" against `docs/schemas/run-report.schema.json` —
+    the schema this loop defines and ships, not an external ATX spec (see
+    module docstring).
+    """
+    import jsonschema
+
+    (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(report, schema)
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_failed_test_has_failed_outcome_in_the_report(tmp_path):
+    (tmp_path / "test_sample.py").write_text(FAILING_TEST)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+    (test,) = report["tests"]
+    assert test["nodeid"] == "test_sample.py::test_not_ok"
+    assert test["outcome"] == "failed"
+
+
+@SKIP
+def test_skipped_test_has_skipped_outcome_not_silently_dropped(tmp_path):
+    (tmp_path / "test_sample.py").write_text(MIXED_SUITE)
+
+    run_pytest("test_sample.py", cwd=tmp_path)
+
+    report = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+    by_id = {test["nodeid"]: test for test in report["tests"]}
+    assert by_id["test_sample.py::test_c"]["outcome"] == "skipped"


### PR DESCRIPTION
## What this changes and why
Closes #41

Implements `TOOL-REQ-032`: "A completed test run also produces a JSON report suitable for later ingestion by a results warehouse (a later-layer concern, not built now — just don't block it)." Extends the `pytest_configure` hook RUN-03 added to `tapwright.runner.plugin` to also auto-enable `--json-report` with zero required flags, wrapping `pytest-json-report` (MIT, new dependency) rather than reimplementing report generation.

**Priority + scope, flagged before implementation started**: the plan's own loop table rated this "Must," but `TOOL-REQ-032` itself rates itself "Should" — filed and treated as Should. "Schema-validates" (the plan's own acceptance line) is against a new schema this loop defines and ships (`docs/schemas/run-report.schema.json`), not the full ASAM ATX standard `TOOL-REQ-032`'s title mentions — the requirement's own wording ("not built now, just don't block it") rules that out for now.

## Type of change
- [x] New feature

## How this was tested
- `tests/integration/test_json_report.py`: 7 cases, every one spawns a genuine subprocess `pytest` run against a throwaway suite — happy path (auto-generates, contains every result), edge cases (explicit `--json-report-file=` honored, round-trips through `json.loads`/`json.dumps`, validates against our schema), error cases (failed/skipped outcomes correctly recorded, not dropped)
- One genuine design gap found via TDD, not a product bug: `pytest-json-report` splits "enabled" (`--json-report`, a bool) from "where" (`--json-report-file`, its own separate default) into two options, unlike `pytest-html`'s single option. Naively checking only the bool would both fail to honor an explicitly-chosen path and overwrite it with our own default — fixed by detecting whether the file-path option differs from the library's own default before deciding whether to apply ours.
- Ran both `test_html_report.py` and `test_json_report.py` together to confirm the two auto-enabled plugins don't interfere with each other — all 14 cases pass
- `ruff check .` / `ruff format --check .` — clean
- `mypy src` — clean
- `pytest --cov=tapwright --cov-report=term-missing` — 165 passed, 86 skipped, 2 pre-existing failures (RUN-08's documented Docker-Desktop-VM vcan gap, unrelated to this change)
- `tools/check_spdx.py`, `check_forbidden.py`, `check_licences.py` (16 dependencies now, `pytest-json-report` + `jsonschema` verified MIT/allowed), `check_fixtures.py`, `check_blast_radius.py` — all pass

## Checklist
- [x] DCO sign-off on all commits
- [x] Tests added (test plan committed separately at b3f67dc, implemented here)
- [x] CHANGELOG.md updated
- [x] Lint/format/type-check clean
- [x] Doesn't touch `diag/`'s public API — `docs/architecture.md` §4 re-read not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)