### PR TITLE
feat(trace): BLF + ASC read/write via python-can (BUS-05, TOOL-REQ-019/020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **BLF + ASC trace read/write** (BUS-05, `TOOL-REQ-019`/`TOOL-REQ-020`;
+  #45): `tapwright.trace.write_blf()`/`read_blf()` and
+  `write_asc()`/`read_asc()`, wrapping `python-can`'s own
+  `BLFReader`/`BLFWriter`/`ASCReader`/`ASCWriter` (already a required
+  dependency) rather than reimplementing either format. `hal.Frame` gains
+  a `timestamp` field (default `0.0`, fully backward compatible) — BLF/ASC
+  are fundamentally timestamped formats, and `Frame` had no timing field
+  at all before this loop. `read_asc()` hardens against a real gap found
+  directly while implementing this: `python-can`'s own `ASCReader`
+  silently returns zero frames for a file that isn't a valid ASC trace at
+  all, rather than raising — `read_asc()` now checks for the header line
+  `ASCWriter` always writes first, raising `TraceLoadError` instead.
+  **Known gap**: no real Vector-CANoe-exported file is available in this
+  environment, so true CANoe interop is unverified — only round-tripping
+  through `python-can`'s own implementation is tested (both directions:
+  what we write, `python-can`'s own reader also reads, and vice versa).
 - **Capability-mismatch property test** (HAL-07, `TOOL-REQ-009`; #43): 7
   new test cases (`tests/integration/test_hal_capability.py`) confirming
   `Bus.send()` raises a clear `CapabilityError` — never a silent failure

--- a/src/tapwright/hal/frame.py
+++ b/src/tapwright/hal/frame.py
@@ -17,9 +17,17 @@ class Frame:
     data: the payload — up to 8 bytes for classic CAN, up to 64 for CAN-FD.
     is_extended_id: True for a 29-bit extended arbitration ID.
     is_fd: True for a CAN-FD frame.
+    timestamp: seconds, meaning depends on where the frame came from — a
+        live `Bus.recv()` (not yet populated; HAL's own read/write path
+        doesn't need frame timing) vs. a recorded trace (`tapwright.trace`,
+        BUS-05), where BLF/ASC store it relative to the trace's first
+        frame, not as a wall-clock value. Defaults to 0.0 so every existing
+        `Frame(...)` call site — none of which construct traces — is
+        unaffected.
     """
 
     arbitration_id: int
     data: bytes
     is_extended_id: bool = False
     is_fd: bool = False
+    timestamp: float = 0.0

--- a/src/tapwright/trace/__init__.py
+++ b/src/tapwright/trace/__init__.py
@@ -6,5 +6,22 @@ BLF, ASC, and MDF4 read and write — interop with the Vector-format
 installed base is non-negotiable, not just self-consistency. See
 ARCHITECTURE.md at the repository root.
 
-Not yet implemented — this is scaffolding for Milestone M3.
+Implemented so far: `io.py` (BUS-05, `TOOL-REQ-019`/`TOOL-REQ-020`) —
+`write_blf()`/`read_blf()` and `write_asc()`/`read_asc()`, wrapping
+`python-can`'s own reader/writer classes rather than reimplementing either
+format. MDF4 (`TOOL-REQ-021`, BUS-06) is not yet built.
 """
+
+from __future__ import annotations
+
+from .errors import TraceError, TraceLoadError
+from .io import read_asc, read_blf, write_asc, write_blf
+
+__all__ = [
+    "TraceError",
+    "TraceLoadError",
+    "read_asc",
+    "read_blf",
+    "write_asc",
+    "write_blf",
+]

--- a/src/tapwright/trace/errors.py
+++ b/src/tapwright/trace/errors.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Errors raised at the L1 trace read/write boundary.
+
+Mirrors `hal.errors`'/`dbc_arxml.errors`' convention: every failure this
+module's public API raises is a `TraceError` subclass, so a caller never
+has to catch a `python-can`-internal exception type to handle a trace
+read/write failure.
+"""
+
+from __future__ import annotations
+
+
+class TraceError(Exception):
+    """Base class for every error raised by tapwright.trace's public API."""
+
+
+class TraceLoadError(TraceError):
+    """A trace file could not be read — missing, unreadable, or not a
+    valid BLF/ASC file."""

--- a/src/tapwright/trace/io.py
+++ b/src/tapwright/trace/io.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""BLF + ASC trace read/write via `python-can` (BUS-05, `TOOL-REQ-019`,
+`TOOL-REQ-020`).
+
+Per `AGENTS.md`'s reuse rule, this wraps `can.io.BLFReader`/`BLFWriter`/
+`ASCReader`/`ASCWriter` (`python-can` is already a required dependency)
+rather than reimplementing either format. The only thing this module adds
+is bridging to/from `tapwright.hal.Frame`.
+
+`ASCReader.__iter__()` silently returns zero messages for a file that
+isn't a valid ASC trace at all (confirmed directly: feeding it arbitrary
+non-ASC text raises nothing and just yields an empty iterator) — exactly
+the "silent failure" this project's own philosophy rejects (see
+`hal.errors.CapabilityError`'s own docstring, `TOOL-REQ-009`). `read_asc()`
+checks for the header line `ASCWriter` always writes before handing off to
+`python-can`, so a non-ASC file raises `TraceLoadError` instead of quietly
+looking like an empty trace.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterable
+from pathlib import Path
+
+import can
+
+from tapwright.hal import Frame
+
+from .errors import TraceLoadError
+
+
+def _frame_to_message(frame: Frame) -> can.Message:
+    return can.Message(
+        arbitration_id=frame.arbitration_id,
+        data=frame.data,
+        is_extended_id=frame.is_extended_id,
+        is_fd=frame.is_fd,
+        timestamp=frame.timestamp,
+    )
+
+
+def _message_to_frame(message: can.Message) -> Frame:
+    return Frame(
+        arbitration_id=message.arbitration_id,
+        data=bytes(message.data),
+        is_extended_id=message.is_extended_id,
+        is_fd=message.is_fd,
+        timestamp=message.timestamp,
+    )
+
+
+def write_blf(frames: Iterable[Frame], path: str | Path) -> None:
+    """Write `frames` to a BLF trace file."""
+    with can.io.BLFWriter(path) as writer:
+        for frame in frames:
+            writer.on_message_received(_frame_to_message(frame))
+
+
+def read_blf(path: str | Path) -> list[Frame]:
+    """Read every frame from a BLF trace file, in recorded order."""
+    try:
+        with can.io.BLFReader(path) as reader:
+            return [_message_to_frame(message) for message in reader]
+    except (OSError, can.CanError, struct.error) as exc:
+        raise TraceLoadError(f"could not read BLF file {path!r}: {exc}") from exc
+
+
+def write_asc(frames: Iterable[Frame], path: str | Path) -> None:
+    """Write `frames` to an ASC trace file."""
+    with can.io.ASCWriter(path) as writer:
+        for frame in frames:
+            writer.on_message_received(_frame_to_message(frame))
+
+
+def read_asc(path: str | Path) -> list[Frame]:
+    """Read every frame from an ASC trace file, in recorded order."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            first_line = fh.readline()
+    except OSError as exc:
+        raise TraceLoadError(f"could not read ASC file {path!r}: {exc}") from exc
+
+    if not first_line.startswith("date "):
+        raise TraceLoadError(
+            f"{path!r} does not look like an ASC trace (expected a 'date' header line)"
+        )
+
+    try:
+        with can.io.ASCReader(path) as reader:
+            return [_message_to_frame(message) for message in reader]
+    except (OSError, can.CanError) as exc:
+        raise TraceLoadError(f"could not read ASC file {path!r}: {exc}") from exc

--- a/tests/differential/test_trace_io.py
+++ b/tests/differential/test_trace_io.py
@@ -60,8 +60,6 @@ import pytest
 from tapwright.hal import Frame
 from tapwright.trace import TraceLoadError, read_asc, read_blf, write_asc, write_blf
 
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #45)")
-
 FRAMES = [
     Frame(arbitration_id=0x123, data=b"\x01\x02\x03", is_extended_id=False),
     Frame(arbitration_id=0x1ABCDEF0, data=b"\xff" * 8, is_extended_id=True),
@@ -73,7 +71,6 @@ FRAMES = [
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_blf_round_trips_through_our_own_writer_and_reader(tmp_path):
     path = tmp_path / "trace.blf"
     write_blf(FRAMES, path)
@@ -84,7 +81,6 @@ def test_blf_round_trips_through_our_own_writer_and_reader(tmp_path):
     ]
 
 
-@SKIP
 def test_asc_round_trips_through_our_own_writer_and_reader(tmp_path):
     path = tmp_path / "trace.asc"
     write_asc(FRAMES, path)
@@ -95,7 +91,6 @@ def test_asc_round_trips_through_our_own_writer_and_reader(tmp_path):
     ]
 
 
-@SKIP
 def test_blf_written_by_us_reads_correctly_via_python_can_directly(tmp_path):
     """The differential half: what we write, `python-can`'s own reader
     (not ours) also reads correctly -- proves our writer produces a
@@ -113,7 +108,6 @@ def test_blf_written_by_us_reads_correctly_via_python_can_directly(tmp_path):
     ]
 
 
-@SKIP
 def test_asc_written_by_python_can_directly_reads_correctly_via_us(tmp_path):
     """The other differential half: a file `python-can` itself produced
     (not ours) reads correctly through our own reader.
@@ -140,7 +134,6 @@ def test_asc_written_by_python_can_directly_reads_correctly_via_us(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 @pytest.mark.parametrize(
     ("write_fn", "read_fn", "ext"),
     [(write_blf, read_blf, "blf"), (write_asc, read_asc, "asc")],
@@ -156,7 +149,6 @@ def test_can_fd_frame_round_trips(tmp_path, write_fn, read_fn, ext):
     assert result.data == fd_frame.data
 
 
-@SKIP
 @pytest.mark.parametrize(
     ("write_fn", "read_fn", "ext"),
     [(write_blf, read_blf, "blf"), (write_asc, read_asc, "asc")],
@@ -167,7 +159,6 @@ def test_empty_trace_round_trips_to_zero_frames_not_a_crash(tmp_path, write_fn, 
     assert read_fn(path) == []
 
 
-@SKIP
 @pytest.mark.parametrize(
     ("write_fn", "read_fn", "ext"),
     [(write_blf, read_blf, "blf"), (write_asc, read_asc, "asc")],
@@ -192,14 +183,12 @@ def test_relative_timing_between_frames_is_preserved(tmp_path, write_fn, read_fn
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 @pytest.mark.parametrize("read_fn", [read_blf, read_asc])
 def test_reading_a_missing_file_raises_clear_error(tmp_path, read_fn):
     with pytest.raises(TraceLoadError):
         read_fn(tmp_path / "does_not_exist")
 
 
-@SKIP
 @pytest.mark.parametrize("read_fn,ext", [(read_blf, "blf"), (read_asc, "asc")])
 def test_reading_a_corrupted_file_raises_clear_error_not_a_crash(tmp_path, read_fn, ext):
     path = tmp_path / f"garbage.{ext}"

--- a/tests/differential/test_trace_io.py
+++ b/tests/differential/test_trace_io.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T3 (subsumed under BUS-05's declared T4) differential test plan for
+BUS-05 — BLF + ASC trace read/write via `python-can` (`TOOL-REQ-019`,
+`TOOL-REQ-020`).
+
+Implements #45. Oracle is the plan's own line: "Round-trip byte-fidelity
+on recorded fixtures." Per `AGENTS.md`'s reuse rule, `python-can`
+(already a required dependency) already implements both formats natively
+(`can.io.BLFReader`/`BLFWriter`/`ASCReader`/`ASCWriter`) — every case here
+writes through `tapwright.trace`'s own wrapper and reads back through
+`python-can`'s reader classes directly (and vice versa), so a mismatch
+between our wrapper and the format `python-can` itself produces/consumes
+would show up immediately, the same differential-oracle shape BUS-01/02
+established for `cantools`.
+
+## Scope note (posted in full to #45; kept here as a pointer)
+
+**Real Vector CANoe interop is not verified.** No CANoe-exported BLF/ASC
+file is available in this environment to test against. Fixtures are
+self-authored by writing known frames through `python-can`'s own
+writer classes (which implement the published Vector formats) and reading
+them back — proving *our* wrapper round-trips correctly through
+`python-can`'s implementation, not that a real CANoe-produced file opens
+correctly here or vice versa. Flagged as a known gap rather than silently
+claimed as proven; closing it needs an actual CANoe export, which isn't
+available to an agent.
+
+## `hal.Frame` gains a `timestamp` field
+
+Found while designing this plan: `Frame` had no timing field at all, but
+BLF/ASC are fundamentally timestamped-trace formats — a trace without
+per-frame timing isn't a meaningful trace. Added `timestamp: float = 0.0`
+(a trailing field with a default, so every existing `Frame(...)` call site
+is unaffected). Deliberately scoped narrowly: `hal.Bus.send()`/`recv()`
+are *not* touched by this loop — populating live-capture timestamps there
+is a separate concern (HAL-01/02's own already-closed loop) from
+trace-file round-tripping, flagged as a natural follow-up rather than
+addressed here.
+
+## Format properties discovered while researching this plan (both formats)
+
+- **Timestamps round-trip as relative deltas from the first message, not
+  absolute values** — confirmed directly: writing messages timestamped
+  1.5s and 2.0s reads back as 0.0s and 0.5s. Tests compare relative
+  deltas, not absolute timestamps.
+- **ASC embeds a wall-clock "date" header line at write time** — the raw
+  file is not byte-identical across writes on different days (same class
+  of non-determinism RUN-03 already found in `pytest-html`'s own
+  template). Tests compare decoded frame content, not raw file bytes.
+- Both formats round-trip CAN-FD frames correctly (`is_fd=True`),
+  confirmed directly.
+"""
+
+from __future__ import annotations
+
+import can
+import pytest
+
+from tapwright.hal import Frame
+from tapwright.trace import TraceLoadError, read_asc, read_blf, write_asc, write_blf
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #45)")
+
+FRAMES = [
+    Frame(arbitration_id=0x123, data=b"\x01\x02\x03", is_extended_id=False),
+    Frame(arbitration_id=0x1ABCDEF0, data=b"\xff" * 8, is_extended_id=True),
+]
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_blf_round_trips_through_our_own_writer_and_reader(tmp_path):
+    path = tmp_path / "trace.blf"
+    write_blf(FRAMES, path)
+    result = read_blf(path)
+
+    assert [(f.arbitration_id, f.data, f.is_extended_id) for f in result] == [
+        (f.arbitration_id, f.data, f.is_extended_id) for f in FRAMES
+    ]
+
+
+@SKIP
+def test_asc_round_trips_through_our_own_writer_and_reader(tmp_path):
+    path = tmp_path / "trace.asc"
+    write_asc(FRAMES, path)
+    result = read_asc(path)
+
+    assert [(f.arbitration_id, f.data, f.is_extended_id) for f in result] == [
+        (f.arbitration_id, f.data, f.is_extended_id) for f in FRAMES
+    ]
+
+
+@SKIP
+def test_blf_written_by_us_reads_correctly_via_python_can_directly(tmp_path):
+    """The differential half: what we write, `python-can`'s own reader
+    (not ours) also reads correctly -- proves our writer produces a
+    genuinely standard BLF file, not just one our own reader happens to
+    tolerate.
+    """
+    path = tmp_path / "trace.blf"
+    write_blf(FRAMES, path)
+
+    with can.io.BLFReader(path) as reader:
+        oracle_result = list(reader)
+
+    assert [(m.arbitration_id, bytes(m.data), m.is_extended_id) for m in oracle_result] == [
+        (f.arbitration_id, f.data, f.is_extended_id) for f in FRAMES
+    ]
+
+
+@SKIP
+def test_asc_written_by_python_can_directly_reads_correctly_via_us(tmp_path):
+    """The other differential half: a file `python-can` itself produced
+    (not ours) reads correctly through our own reader.
+    """
+    path = tmp_path / "trace.asc"
+    with can.io.ASCWriter(path) as writer:
+        for frame in FRAMES:
+            writer.on_message_received(
+                can.Message(
+                    arbitration_id=frame.arbitration_id,
+                    data=frame.data,
+                    is_extended_id=frame.is_extended_id,
+                )
+            )
+
+    result = read_asc(path)
+    assert [(f.arbitration_id, f.data, f.is_extended_id) for f in result] == [
+        (f.arbitration_id, f.data, f.is_extended_id) for f in FRAMES
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+@pytest.mark.parametrize(
+    ("write_fn", "read_fn", "ext"),
+    [(write_blf, read_blf, "blf"), (write_asc, read_asc, "asc")],
+)
+def test_can_fd_frame_round_trips(tmp_path, write_fn, read_fn, ext):
+    path = tmp_path / f"trace.{ext}"
+    fd_frame = Frame(arbitration_id=0x321, data=b"\xaa" * 20, is_extended_id=False, is_fd=True)
+
+    write_fn([fd_frame], path)
+    (result,) = read_fn(path)
+
+    assert result.is_fd is True
+    assert result.data == fd_frame.data
+
+
+@SKIP
+@pytest.mark.parametrize(
+    ("write_fn", "read_fn", "ext"),
+    [(write_blf, read_blf, "blf"), (write_asc, read_asc, "asc")],
+)
+def test_empty_trace_round_trips_to_zero_frames_not_a_crash(tmp_path, write_fn, read_fn, ext):
+    path = tmp_path / f"trace.{ext}"
+    write_fn([], path)
+    assert read_fn(path) == []
+
+
+@SKIP
+@pytest.mark.parametrize(
+    ("write_fn", "read_fn", "ext"),
+    [(write_blf, read_blf, "blf"), (write_asc, read_asc, "asc")],
+)
+def test_relative_timing_between_frames_is_preserved(tmp_path, write_fn, read_fn, ext):
+    """Documents and locks in the relative-timestamp behavior found while
+    researching this plan -- absolute timestamps are not preserved by
+    either format, but the *delta* between frames must be.
+    """
+    path = tmp_path / f"trace.{ext}"
+    early = Frame(arbitration_id=0x1, data=b"\x01", timestamp=1.5)
+    late = Frame(arbitration_id=0x2, data=b"\x02", timestamp=2.0)
+
+    write_fn([early, late], path)
+    first, second = read_fn(path)
+
+    assert second.timestamp - first.timestamp == pytest.approx(0.5, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+@pytest.mark.parametrize("read_fn", [read_blf, read_asc])
+def test_reading_a_missing_file_raises_clear_error(tmp_path, read_fn):
+    with pytest.raises(TraceLoadError):
+        read_fn(tmp_path / "does_not_exist")
+
+
+@SKIP
+@pytest.mark.parametrize("read_fn,ext", [(read_blf, "blf"), (read_asc, "asc")])
+def test_reading_a_corrupted_file_raises_clear_error_not_a_crash(tmp_path, read_fn, ext):
+    path = tmp_path / f"garbage.{ext}"
+    path.write_bytes(b"this is not a valid trace file at all")
+
+    with pytest.raises(TraceLoadError):
+        read_fn(path)


### PR DESCRIPTION
## What this changes and why
Closes #45

Implements `TOOL-REQ-019` (BLF) and `TOOL-REQ-020` (ASC), both Must: "A trace recorded by the product opens correctly in Vector CANoe/CANalyzer, and a BLF/ASC file exported from CANoe decodes correctly in this product." `python-can` (already a required dependency) already implements both formats natively — `write_blf()`/`read_blf()` and `write_asc()`/`read_asc()` wrap `can.io.BLFReader`/`BLFWriter`/`ASCReader`/`ASCWriter` rather than reimplementing either format, matching the reuse pattern BUS-01's `dbc_arxml.database` already established for `cantools`.

`hal.Frame` gains a `timestamp` field (default `0.0`, backward compatible — all 12 existing `Frame(...)` call sites are unaffected) — BLF/ASC are fundamentally timestamped formats and `Frame` had none before this loop. `hal.Bus.send()`/`recv()` are deliberately untouched; populating live-capture timestamps is a separate concern from trace-file round-tripping.

**A real hardening fix found while implementing**: `python-can`'s own `ASCReader` silently returns zero frames for a file that isn't a valid ASC trace at all, rather than raising — confirmed directly. `read_asc()` now checks for the header line `ASCWriter` always writes before handing off to `python-can`, raising `TraceLoadError` instead of silently looking like an empty trace.

**Known gap, flagged rather than silently claimed as proven**: no real Vector-CANoe-exported file is available in this environment, so true CANoe interop is unverified — only round-tripping through `python-can`'s own implementation is tested, in both directions (what we write, `python-can`'s reader also reads; what `python-can` writes, our reader also reads).

## Type of change
- [x] New feature

## How this was tested
- `tests/differential/test_trace_io.py`: 14 cases (4 direct + 6 parametrized across BLF/ASC) — happy path (round-trips through our own writer+reader, and the differential half both ways through `python-can` directly), edge cases (CAN-FD frames, empty traces, relative timing preservation), error cases (missing file, corrupted file)
- All 14 pass on the first run
- `ruff check .` / `ruff format --check .` — clean
- `mypy src` — clean
- `pytest --cov=tapwright --cov-report=term-missing` — 179 passed, 93 skipped, 2 pre-existing failures (RUN-08's documented Docker-Desktop-VM vcan gap, unrelated to this change); `trace/io.py` at 95% coverage
- `tools/check_spdx.py`, `check_forbidden.py`, `check_licences.py`, `check_fixtures.py`, `check_blast_radius.py` — all pass

## Checklist
- [x] DCO sign-off on all commits
- [x] Tests added (test plan committed separately at f47029c, implemented here)
- [x] CHANGELOG.md updated
- [x] Lint/format/type-check clean
- [x] Doesn't touch `diag/`'s public API — `docs/architecture.md` §4 re-read not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)