### PR TITLE
feat(buses): add cyclic-send engine with DBC-driven cycle times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **Cyclic-send engine, DBC-driven cycle times** (BUS-07, `TOOL-REQ-011`;
+  #49): `hal.Bus.send_periodic()` (wrapping `python-can`'s own
+  `BusABC.send_periodic()`) for explicit-period cyclic transmission, plus
+  `tapwright.buses.start_cyclic_from_dbc()` deriving the period
+  automatically from an already-loaded `CanDatabase`'s declared
+  `GenMsgCycleTime` (raising `ValueError` if none is declared and no
+  explicit period is given). Scoped to single/multi-*message* cyclic
+  stimulation per `TOOL-REQ-011`'s own Must-priority acceptance criterion
+  — not multi-node restbus simulation with node-behavior scripting
+  (`TOOL-REQ-012`, Should/Fast-follow, out of scope; see issue #49 for the
+  scope correction against the plan's own loop-table title).
 - **Cold-clone GitHub Actions example** (RUN-06, `TOOL-REQ-033`; #47):
   `examples/github-actions/` — a standalone, cold-clone-able example of
   testing UDS diagnostics with `tapwright` in CI (one small test using

--- a/fixtures/databases/cyclic.dbc
+++ b/fixtures/databases/cyclic.dbc
@@ -1,0 +1,18 @@
+VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: ECU Tester
+
+BO_ 100 EngineData: 4 ECU
+ SG_ EngineSpeed : 0|16@1+ (1,0) [0|65535] "rpm" Tester
+ SG_ EngineTemp : 16|8@1+ (1,-40) [0|215] "degC" Tester
+
+BO_ 200 NoCycleMessage: 2 ECU
+ SG_ Flag : 0|8@1+ (1,0) [0|255] "" Tester
+
+BA_DEF_ BO_ "GenMsgCycleTime" INT 0 100000;
+BA_DEF_DEF_ "GenMsgCycleTime" 0;
+BA_ "GenMsgCycleTime" BO_ 100 50;

--- a/fixtures/provenance.toml
+++ b/fixtures/provenance.toml
@@ -142,3 +142,93 @@ source = "Decoded by cantools 42.0.3 directly against multiplexed.dbc"
 added = "2026-08-18"
 verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
 description = "Golden decode of MuxMessage with MuxSelector=1, selecting MuxedSignalB — same raw payload as selector_0 except the selector byte, decoding to a different signal entirely"
+
+[[fixture]]
+path = "databases/cyclic.dbc"
+sha256 = "084ef60d1c02d8abbd0335a9b89726ab15dee897a50248708c884d6372be6ce8"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Written for BUS-07 (issue #49); no external source"
+added = "2026-09-02"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Two messages for cyclic-send tests: EngineData declares GenMsgCycleTime=50 (ms), NoCycleMessage declares none -- exercising both the DBC-driven automatic-period path and its ValueError-on-missing-cycle-time error case"
+
+[[fixture]]
+path = "databases/multiplexed.dbc"
+sha256 = "48bbcf5ac38d832a1b2dc0d33e94c76c3e06101afeca68c5733266fea61cd671"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Written for BUS-01 (issue #22); no external source"
+added = "2026-08-18"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Three messages exercising DBC decode edge cases: EngineData (standard 11-bit ID, plain scaling, a negative offset), ExtendedMsg (29-bit extended ID), MuxMessage (a multiplexor signal selecting between two differently-scaled multiplexed signals)"
+
+[[fixture]]
+path = "databases/vehicle_signals.arxml"
+sha256 = "eabe80162b4f239cdef894e09841c05fdf9b50923d698cbba73a9c79d8642ed7"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Written for BUS-02 (issue #37); no external source. No suitable public-domain AUTOSAR ARXML with the right property mix (plain scaling, negative offset, 29-bit extended ID) was found"
+added = "2026-08-25"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Two AUTOSAR 4.x CAN frames: VehicleStatus (standard 11-bit ID, a scaled signal, a negative-offset signal) and ExtendedDiag (29-bit extended ID)"
+
+[[fixture]]
+path = "expected/arxml_extended_diag.json"
+sha256 = "5bb81f2fa47da83abf36fe536c457063d1df2e343c2c6945e65b1444635d7ba1"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Decoded by cantools 42.0.3 directly against vehicle_signals.arxml, force_extended_id=True"
+added = "2026-08-25"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Golden decode of ExtendedDiag: a 29-bit extended arbitration ID, ARXML-sourced"
+
+[[fixture]]
+path = "expected/arxml_vehicle_status.json"
+sha256 = "84039f87f901808137260466250d0bfc29beb9a1fc46034427446a6655e45e77"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Decoded by cantools 42.0.3 directly against vehicle_signals.arxml; hand-verified against the ARXML's own COMPU-RATIONAL-COEFFS"
+added = "2026-08-25"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Golden decode of VehicleStatus: a scaled signal and a negative-offset signal, ARXML-sourced"
+
+[[fixture]]
+path = "expected/dbc_multiplexed_engine_data.json"
+sha256 = "96064ed42ee494111abb28c8cfaad571c97ae458ad8965f41004edbd31da7155"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Decoded by cantools 42.0.3 directly against multiplexed.dbc; hand-verified against the DBC's own scale/offset lines"
+added = "2026-08-18"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Golden decode of EngineData: plain scaling (EngineSpeed) and a negative offset (EngineTemp)"
+
+[[fixture]]
+path = "expected/dbc_multiplexed_extended_msg.json"
+sha256 = "cd9af25d0c064878cbd7ba4e1c8dd213842b9989944ccf52a70a43501fb89be1"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Decoded by cantools 42.0.3 directly against multiplexed.dbc, force_extended_id=True"
+added = "2026-08-18"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Golden decode of ExtendedMsg: a 29-bit extended arbitration ID"
+
+[[fixture]]
+path = "expected/dbc_multiplexed_mux_selector_0.json"
+sha256 = "29e8880e8d812ca52a976a0151a68cc23a182cb3f308510699478e02b6964294"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Decoded by cantools 42.0.3 directly against multiplexed.dbc"
+added = "2026-08-18"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Golden decode of MuxMessage with MuxSelector=0, selecting MuxedSignalA"
+
+[[fixture]]
+path = "expected/dbc_multiplexed_mux_selector_1.json"
+sha256 = "1e3549533968fdf7a84e5b748d30efb3444cd8eb811f3334dad3f4ae85f6702c"
+origin = "self-authored"
+licence = "Apache-2.0"
+source = "Decoded by cantools 42.0.3 directly against multiplexed.dbc"
+added = "2026-08-18"
+verified_by = "DeepanshuPandey22 (pending explicit confirmation -- see PR description)"
+description = "Golden decode of MuxMessage with MuxSelector=1, selecting MuxedSignalB — same raw payload as selector_0 except the selector byte, decoding to a different signal entirely"

--- a/src/tapwright/buses/__init__.py
+++ b/src/tapwright/buses/__init__.py
@@ -5,5 +5,12 @@
 Frame-level CAN/CAN-FD/LIN send and receive, basic cyclic stimulation. See
 ARCHITECTURE.md at the repository root.
 
-Not yet implemented — this is scaffolding for Milestone M2.
+Frame-level send/recv lives in `tapwright.hal` (L0). Cyclic stimulation
+(BUS-07, `TOOL-REQ-011`) is this module's own addition, layered on top:
+`hal.Bus.send_periodic()` for the explicit-period path,
+`start_cyclic_from_dbc()` here for the DBC-driven convenience.
 """
+
+from .cyclic import start_cyclic_from_dbc
+
+__all__ = ["start_cyclic_from_dbc"]

--- a/src/tapwright/buses/cyclic.py
+++ b/src/tapwright/buses/cyclic.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cyclic-send engine, DBC-driven cycle times (BUS-07, `TOOL-REQ-011`).
+
+Single/multi-*message* cyclic stimulation — a configured signal transmits
+at a fixed period on vcan. Not multi-node restbus simulation with
+node-behavior scripting (`TOOL-REQ-012`, Should/Fast-follow, out of scope
+here); see issue #49 for the scope correction against the plan's own loop
+table title.
+
+`hal.Bus.send_periodic()` already wraps `can.BusABC.send_periodic()` — the
+only thing this module adds is deriving the period from an already-loaded
+`CanDatabase`'s own declared cycle time, so a caller doesn't have to know
+or restate it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import can
+
+from tapwright.dbc_arxml import CanDatabase
+from tapwright.hal import Bus
+
+
+def start_cyclic_from_dbc(
+    bus: Bus,
+    db: CanDatabase,
+    message_name: str,
+    signals: dict[str, Any],
+    *,
+    period: float | None = None,
+) -> can.broadcastmanager.CyclicSendTaskABC:
+    """Start cyclically sending `message_name`, encoded from `signals` via
+    `db`, at `period` seconds — or, if `period` is omitted, at the
+    database's own declared cycle time for that message.
+
+    Raises `ValueError` if `period` is omitted and the database declares no
+    cycle time for `message_name`, rather than silently defaulting to an
+    arbitrary period.
+    """
+    if period is None:
+        period = db.cycle_time(message_name)
+        if period is None:
+            raise ValueError(
+                f"message {message_name!r} declares no cycle time in the database — "
+                f"pass period= explicitly"
+            )
+
+    frame = db.encode(message_name, signals)
+    return bus.send_periodic(frame, period)

--- a/src/tapwright/dbc_arxml/database.py
+++ b/src/tapwright/dbc_arxml/database.py
@@ -93,6 +93,25 @@ class CanDatabase:
             is_extended_id=message.is_extended_frame,
         )
 
+    def cycle_time(self, message_name: str) -> float | None:
+        """The named message's declared cycle time in seconds (from the
+        DBC's `GenMsgCycleTime` attribute or the ARXML equivalent), or
+        `None` if the database declares no cycle time for it — used by
+        `tapwright.buses.start_cyclic_from_dbc` (`TOOL-REQ-011`) rather
+        than reaching into cantools' own `Message.cycle_time` (milliseconds)
+        directly from outside this module.
+        """
+        try:
+            message = self._db.get_message_by_name(message_name)
+        except KeyError as exc:
+            raise UnknownMessageError(
+                f"no message named {message_name!r} in this database"
+            ) from exc
+
+        if message.cycle_time is None:
+            return None
+        return message.cycle_time / 1000.0
+
 
 def _load(path: str | Path, database_format: str) -> CanDatabase:
     """Shared load path for `load_dbc()`/`load_arxml()`. `database_format`

--- a/src/tapwright/hal/bus.py
+++ b/src/tapwright/hal/bus.py
@@ -42,6 +42,30 @@ class Bus:
         )
         self._raw_bus.send(message)
 
+    def send_periodic(self, frame: Frame, period: float) -> can.broadcastmanager.CyclicSendTaskABC:
+        """Transmit `frame` repeatedly every `period` seconds until stopped.
+
+        TOOL-REQ-011 (basic single/multi-message cyclic stimulation), not
+        multi-node restbus simulation (TOOL-REQ-012, out of scope). Wraps
+        can.BusABC.send_periodic() rather than reimplementing periodic
+        timing — see AGENTS.md §3. The returned task's only public method is
+        stop(); no tapwright-specific wrapper is added around it since there
+        is nothing left to bridge.
+        """
+        if self._closed:
+            raise BusClosedError("cannot send on a bus after shutdown()")
+        if period <= 0:
+            raise ValueError(f"period must be positive, got {period!r}")
+        if frame.is_fd and not self._fd:
+            raise CapabilityError("cannot send a CAN-FD frame on a bus opened without fd=True")
+        message = can.Message(
+            arbitration_id=frame.arbitration_id,
+            data=frame.data,
+            is_extended_id=frame.is_extended_id,
+            is_fd=frame.is_fd,
+        )
+        return self._raw_bus.send_periodic(message, period)
+
     def recv(self, timeout: float | None = None) -> Frame | None:
         if self._closed:
             raise BusClosedError("cannot recv on a bus after shutdown()")

--- a/tests/integration/test_cyclic_send.py
+++ b/tests/integration/test_cyclic_send.py
@@ -35,15 +35,14 @@ import time
 
 import pytest
 
+from tapwright.buses.cyclic import start_cyclic_from_dbc
 from tapwright.dbc_arxml import load_dbc
 from tapwright.hal import Frame, open_bus
 from tapwright.hal.errors import CapabilityError
 
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #49)")
-
 pytestmark = pytest.mark.requires_vcan
 
-FIXTURES_DBC = "fixtures/databases/multiplexed.dbc"
+FIXTURES_DBC = "fixtures/databases/cyclic.dbc"
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +50,6 @@ FIXTURES_DBC = "fixtures/databases/multiplexed.dbc"
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_send_periodic_transmits_repeatedly_at_the_configured_period(vcan_channel):
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
@@ -73,19 +71,17 @@ def test_send_periodic_transmits_repeatedly_at_the_configured_period(vcan_channe
         receiver.shutdown()
 
 
-@SKIP
 def test_dbc_declared_cycle_time_is_used_automatically(vcan_channel):
     """The literal "DBC-driven cycle times" requirement: the caller
     doesn't specify a period at all -- it comes from the loaded
     `CanDatabase`'s own message definition.
     """
-    from tapwright.buses.cyclic import start_cyclic_from_dbc
-
     db = load_dbc(FIXTURES_DBC)
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
     try:
-        task = start_cyclic_from_dbc(sender, db, "EngineData", {"EngineSpeed": 1000.0, "EngineTemp": 60})
+        signals = {"EngineSpeed": 1000.0, "EngineTemp": 60}
+        task = start_cyclic_from_dbc(sender, db, "EngineData", signals)
         try:
             assert receiver.recv(timeout=1.0) is not None
         finally:
@@ -100,7 +96,6 @@ def test_dbc_declared_cycle_time_is_used_automatically(vcan_channel):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_stop_actually_stops_transmission(vcan_channel):
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
@@ -118,24 +113,20 @@ def test_stop_actually_stops_transmission(vcan_channel):
         receiver.shutdown()
 
 
-@SKIP
 def test_dbc_message_with_no_declared_cycle_time_raises_clear_error(vcan_channel):
     """A message the DBC doesn't declare a cycle time for can't silently
     default to something arbitrary -- the caller must be told to supply
     one explicitly.
     """
-    from tapwright.buses.cyclic import start_cyclic_from_dbc
-
-    db = load_dbc(FIXTURES_DBC)  # this fixture's messages declare no GenMsgCycleTime
+    db = load_dbc(FIXTURES_DBC)  # NoCycleMessage declares no GenMsgCycleTime
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     try:
         with pytest.raises(ValueError):
-            start_cyclic_from_dbc(sender, db, "EngineData", {"EngineSpeed": 0.0, "EngineTemp": 0.0})
+            start_cyclic_from_dbc(sender, db, "NoCycleMessage", {"Flag": 0})
     finally:
         sender.shutdown()
 
 
-@SKIP
 def test_multiple_concurrent_cyclic_tasks_do_not_interfere(vcan_channel):
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
@@ -166,7 +157,6 @@ def test_multiple_concurrent_cyclic_tasks_do_not_interfere(vcan_channel):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_non_positive_period_raises_clear_error_immediately(vcan_channel):
     bus = open_bus(backend="socketcan", channel=vcan_channel)
     try:
@@ -176,7 +166,6 @@ def test_non_positive_period_raises_clear_error_immediately(vcan_channel):
         bus.shutdown()
 
 
-@SKIP
 def test_capability_check_still_applies_through_the_periodic_path(vcan_channel):
     """The same `CapabilityError` HAL-07 already proved for `send()` must
     not be bypassable by going through `send_periodic()` instead -- one

--- a/tests/integration/test_cyclic_send.py
+++ b/tests/integration/test_cyclic_send.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T4 (timing property, not `hypothesis`) test plan for BUS-07 — cyclic
+send engine, DBC-driven cycle times (`TOOL-REQ-011`).
+
+Implements #49. Oracle is the plan's own line: "Timing within tolerance
+over N seconds on `vcan`; no drift." Per `AGENTS.md`'s reuse rule,
+`hal.Bus.send_periodic()` wraps `can.BusABC.send_periodic()` (already
+implemented by `python-can`) rather than reimplementing periodic timing.
+
+## Scope note (posted in full to #49; kept here as a pointer)
+
+**Single/multi-*message* cyclic sending, not multi-*node* restbus
+simulation.** The plan's own loop table titles this "multi-node," but the
+underlying requirement (`TOOL-REQ-011`, Must) is scoped to "basic
+stimulation" — full multi-node restbus simulation with node-behavior
+scripting is `TOOL-REQ-012` (Should/Fast-follow, explicitly deferred,
+matching `docs/tooling-requirements.md`'s own Won't-scope entry for a
+"GUI restbus-simulation designer"). Not built here.
+
+## Timing-tolerance note
+
+CI runners are shared, non-realtime VMs — a scheduler jitter budget that a
+real ECU or an RTOS could meet reliably cannot be guaranteed on a shared
+CI host. Cases here use a generously wide tolerance band (not the literal
+±5% `TOOL-REQ-011` names) precisely enough to prove genuinely-cyclic
+behavior (not one-shot, not silently stalled) without being flaky on a
+loaded runner. Honest about the gap rather than either testing a bound CI
+can't reliably meet or silently dropping the timing assertion altogether.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tapwright.dbc_arxml import load_dbc
+from tapwright.hal import Frame, open_bus
+from tapwright.hal.errors import CapabilityError
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #49)")
+
+pytestmark = pytest.mark.requires_vcan
+
+FIXTURES_DBC = "fixtures/databases/multiplexed.dbc"
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_send_periodic_transmits_repeatedly_at_the_configured_period(vcan_channel):
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        task = sender.send_periodic(Frame(arbitration_id=0x100, data=b"\x01"), period=0.05)
+        try:
+            received = 0
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                if receiver.recv(timeout=0.2) is not None:
+                    received += 1
+            # ~20 expected over 1s at 50ms; a wide band tolerant of CI
+            # scheduler jitter (see module docstring), not the literal spec.
+            assert 10 <= received <= 30
+        finally:
+            task.stop()
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+@SKIP
+def test_dbc_declared_cycle_time_is_used_automatically(vcan_channel):
+    """The literal "DBC-driven cycle times" requirement: the caller
+    doesn't specify a period at all -- it comes from the loaded
+    `CanDatabase`'s own message definition.
+    """
+    from tapwright.buses.cyclic import start_cyclic_from_dbc
+
+    db = load_dbc(FIXTURES_DBC)
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        task = start_cyclic_from_dbc(sender, db, "EngineData", {"EngineSpeed": 1000.0, "EngineTemp": 60})
+        try:
+            assert receiver.recv(timeout=1.0) is not None
+        finally:
+            task.stop()
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_stop_actually_stops_transmission(vcan_channel):
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        task = sender.send_periodic(Frame(arbitration_id=0x200, data=b"\x02"), period=0.05)
+        assert receiver.recv(timeout=0.5) is not None  # it's actually running
+        task.stop()
+
+        while receiver.recv(timeout=0) is not None:
+            pass  # drain anything already in flight when stop() was called
+
+        assert receiver.recv(timeout=0.3) is None
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+@SKIP
+def test_dbc_message_with_no_declared_cycle_time_raises_clear_error(vcan_channel):
+    """A message the DBC doesn't declare a cycle time for can't silently
+    default to something arbitrary -- the caller must be told to supply
+    one explicitly.
+    """
+    from tapwright.buses.cyclic import start_cyclic_from_dbc
+
+    db = load_dbc(FIXTURES_DBC)  # this fixture's messages declare no GenMsgCycleTime
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        with pytest.raises(ValueError):
+            start_cyclic_from_dbc(sender, db, "EngineData", {"EngineSpeed": 0.0, "EngineTemp": 0.0})
+    finally:
+        sender.shutdown()
+
+
+@SKIP
+def test_multiple_concurrent_cyclic_tasks_do_not_interfere(vcan_channel):
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        task_a = sender.send_periodic(Frame(arbitration_id=0x10, data=b"\xaa"), period=0.05)
+        task_b = sender.send_periodic(Frame(arbitration_id=0x20, data=b"\xbb"), period=0.05)
+        try:
+            seen_ids = set()
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
+                frame = receiver.recv(timeout=0.2)
+                if frame is not None:
+                    seen_ids.add(frame.arbitration_id)
+            assert seen_ids == {0x10, 0x20}
+
+            task_a.stop()
+            # b keeps running independently of a's stop
+            assert receiver.recv(timeout=0.3) is not None
+        finally:
+            task_b.stop()
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_non_positive_period_raises_clear_error_immediately(vcan_channel):
+    bus = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        with pytest.raises(ValueError):
+            bus.send_periodic(Frame(arbitration_id=0x1, data=b"\x01"), period=0.0)
+    finally:
+        bus.shutdown()
+
+
+@SKIP
+def test_capability_check_still_applies_through_the_periodic_path(vcan_channel):
+    """The same `CapabilityError` HAL-07 already proved for `send()` must
+    not be bypassable by going through `send_periodic()` instead -- one
+    capability check, not two code paths that could drift apart.
+    """
+    bus = open_bus(backend="socketcan", channel=vcan_channel, fd=False)
+    try:
+        with pytest.raises(CapabilityError):
+            bus.send_periodic(Frame(arbitration_id=0x1, data=b"\x01", is_fd=True), period=0.05)
+    finally:
+        bus.shutdown()


### PR DESCRIPTION
## What this changes and why
Closes #49

Implements BUS-07 / `TOOL-REQ-011` (Must): `hal.Bus.send_periodic()` wraps `python-can`'s own `BusABC.send_periodic()` for explicit-period cyclic transmission; `tapwright.buses.start_cyclic_from_dbc()` derives the period automatically from an already-loaded `CanDatabase`'s declared `GenMsgCycleTime`, raising `ValueError` when neither a declared cycle time nor an explicit period is available.

**Scope correction (flagged in #49):** the plan's own loop table titles this loop "multi-node restbus / cyclic-send engine," but the cited requirement (`TOOL-REQ-011`, Must) is scoped to "basic stimulation" — a configured signal transmitting at a fixed period, not multi-node simulated ECUs with node-behavior scripting. That broader scope is `TOOL-REQ-012` (Should/Fast-follow, explicitly deferred) and matches `docs/tooling-requirements.md`'s own Won't-scope entry against a "GUI restbus-simulation designer." This loop builds single/multi-*message* cyclic sending only.

**New fixture:** `fixtures/databases/cyclic.dbc` (self-authored) — the existing `multiplexed.dbc` fixture is immutable (hash-checked) and none of its messages declare a `GenMsgCycleTime`, so a new small fixture was added rather than modifying the golden one. Provenance entry added to `fixtures/provenance.toml`.

## How this was tested
7 cases in `tests/integration/test_cyclic_send.py` (T4/T2-shaped, requires real `vcan` timing — skips locally on Windows, runs against `vcan` in CI):
- happy path: periodic transmission at a configured period; DBC-driven automatic period
- edge cases: `.stop()` actually halts transmission; a DBC message with no declared cycle time raises `ValueError`; multiple concurrent cyclic tasks run independently
- error cases: non-positive period raises `ValueError`; the existing `CapabilityError` (HAL-07) still applies through the periodic path

Local gate: `ruff check`, `ruff format --check`, `mypy src`, `tools/check_fixtures.py` all clean. `pytest --cov` — 178 passed, 100 skipped (incl. the 7 new `vcan`-gated cases), 3 pre-existing failures unrelated to this change (2 known Docker-Desktop-VM-vcan-gap `test_container.py` failures, 1 Windows-only console-script-path issue in `test_cli.py`, confirmed present on `main` before this branch via `git stash`).

## Checklist
- [x] DCO sign-off (`git commit -s`)
- [x] Tests added (skip-stubbed plan → implemented, posted to #49 first)
- [x] CHANGELOG.md updated
- [x] Lint/type-check clean
- [x] `docs/architecture.md` not applicable (no `diag/` public API touched)