### PR TITLE
feat(trace): add MDF4 read/write via python-can's asammdf wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,20 @@ jobs:
         env:
           TAPWRIGHT_CHANNEL: vcan0
 
+  mdf4-extra:
+    name: MDF4 extra (BUS-06)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      # Proves the other half of BUS-06's oracle: t3-differential (above)
+      # installs without [mdf4] and shows these cases skip cleanly; this
+      # job installs *with* it and must show them passing for real.
+      - run: pip install -e ".[dev,mdf4]"
+      - run: pytest tests/differential/test_mdf4_io.py -v
+
   coverage-ratchet:
     name: Coverage ratchet (L0-L2)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **MDF4 trace read/write** (BUS-06, `TOOL-REQ-021`; #51):
+  `tapwright.trace.write_mdf4()`/`read_mdf4()`, wrapping `python-can`'s own
+  `MF4Writer`/`MF4Reader` (which already implement CAN-frame-level MDF4
+  logging on top of `asammdf`) rather than hand-rolling `asammdf.Signal`
+  calls directly. `asammdf` (LGPL-3.0) ships as a new optional extra,
+  `pip install tapwright[mdf4]` — the core installs and passes its full
+  suite without it, matching the isolation precedent already established
+  for `python-can` itself (HAL-08, `FW-REQ-019`). A `python-can` gap found
+  during development: its own `mf4.py` only guards the `asammdf` import
+  with `except ImportError`, so an incompatible `asammdf`/`numpy`
+  combination surfaces as an uncaught `AttributeError` deep inside
+  `python-can` rather than a clean message — `write_mdf4()`/`read_mdf4()`
+  instead catch `python-can`'s own (correctly-raised) `NotImplementedError`
+  for the "not installed at all" case and translate it to `TraceError`
+  naming the extra. **Priority correction, flagged in issue #51**: the
+  plan's own loop table and `LOOPS.md` listed this loop as Should, but the
+  cited requirement, `TOOL-REQ-021`, is rated Must — corrected here.
 - **Cyclic-send engine, DBC-driven cycle times** (BUS-07, `TOOL-REQ-011`;
   #49): `hal.Bus.send_periodic()` (wrapping `python-can`'s own
   `BusABC.send_periodic()`) for explicit-period cyclic transmission, plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ dev = [
     "pre-commit",
     "tomli; python_version<'3.11'",  # tomllib landed in 3.11; the floor is 3.10
 ]
+# BUS-06 / TOOL-REQ-021 / FW-REQ-015: MDF4 read/write. asammdf is LGPL-3.0,
+# so it ships as an optional extra rather than a core dependency — the core
+# installs and passes its full suite without it (FW-REQ-019's isolation
+# boundary, same precedent as python-can/HAL-08).
+mdf4 = [
+    "asammdf>=8",
+]
 
 # RUN-01 / TOOL-REQ-028: auto-discovered on `pip install tapwright` — a user
 # needs no `pytest_plugins = [...]` to get the ecu/bus/uds fixtures. This

--- a/src/tapwright/trace/__init__.py
+++ b/src/tapwright/trace/__init__.py
@@ -6,22 +6,25 @@ BLF, ASC, and MDF4 read and write — interop with the Vector-format
 installed base is non-negotiable, not just self-consistency. See
 ARCHITECTURE.md at the repository root.
 
-Implemented so far: `io.py` (BUS-05, `TOOL-REQ-019`/`TOOL-REQ-020`) —
-`write_blf()`/`read_blf()` and `write_asc()`/`read_asc()`, wrapping
-`python-can`'s own reader/writer classes rather than reimplementing either
-format. MDF4 (`TOOL-REQ-021`, BUS-06) is not yet built.
+`io.py` wraps `python-can`'s own reader/writer classes rather than
+reimplementing any format: `write_blf()`/`read_blf()` and
+`write_asc()`/`read_asc()` (BUS-05, `TOOL-REQ-019`/`TOOL-REQ-020`),
+`write_mdf4()`/`read_mdf4()` (BUS-06, `TOOL-REQ-021` — requires the
+optional `mdf4` extra, `pip install tapwright[mdf4]`).
 """
 
 from __future__ import annotations
 
 from .errors import TraceError, TraceLoadError
-from .io import read_asc, read_blf, write_asc, write_blf
+from .io import read_asc, read_blf, read_mdf4, write_asc, write_blf, write_mdf4
 
 __all__ = [
     "TraceError",
     "TraceLoadError",
     "read_asc",
     "read_blf",
+    "read_mdf4",
     "write_asc",
     "write_blf",
+    "write_mdf4",
 ]

--- a/src/tapwright/trace/io.py
+++ b/src/tapwright/trace/io.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""BLF + ASC trace read/write via `python-can` (BUS-05, `TOOL-REQ-019`,
-`TOOL-REQ-020`).
+"""BLF + ASC + MDF4 trace read/write via `python-can` (BUS-05
+`TOOL-REQ-019`/`TOOL-REQ-020`; BUS-06 `TOOL-REQ-021`).
 
 Per `AGENTS.md`'s reuse rule, this wraps `can.io.BLFReader`/`BLFWriter`/
-`ASCReader`/`ASCWriter` (`python-can` is already a required dependency)
-rather than reimplementing either format. The only thing this module adds
-is bridging to/from `tapwright.hal.Frame`.
+`ASCReader`/`ASCWriter`/`MF4Reader`/`MF4Writer` (`python-can` is already a
+required dependency) rather than reimplementing any of these formats. The
+only thing this module adds is bridging to/from `tapwright.hal.Frame`.
 
 `ASCReader.__iter__()` silently returns zero messages for a file that
 isn't a valid ASC trace at all (confirmed directly: feeding it arbitrary
@@ -16,6 +16,15 @@ the "silent failure" this project's own philosophy rejects (see
 checks for the header line `ASCWriter` always writes before handing off to
 `python-can`, so a non-ASC file raises `TraceLoadError` instead of quietly
 looking like an empty trace.
+
+MDF4 needs `asammdf` (LGPL-3.0), which `python-can`'s own `can.io.mf4`
+module already imports only under a guarded `try`/`except ImportError` —
+ships as tapwright's own optional `mdf4` extra (`FW-REQ-015`, `FW-REQ-019`;
+dependency-only, never vendored, matching the `python-can` precedent from
+HAL-08). `write_mdf4()`/`read_mdf4()` translate `python-can`'s own
+`NotImplementedError` (raised when `asammdf` isn't installed) into
+`TraceError`, so a caller doesn't need to know `python-can`'s internals to
+learn what to install.
 """
 
 from __future__ import annotations
@@ -28,7 +37,15 @@ import can
 
 from tapwright.hal import Frame
 
-from .errors import TraceLoadError
+from .errors import TraceError, TraceLoadError
+
+_MDF_EXCEPTIONS: tuple[type[BaseException], ...]
+try:
+    from asammdf.blocks.utils import MdfException  # type: ignore[import-not-found]
+
+    _MDF_EXCEPTIONS = (MdfException,)
+except ImportError:  # the mdf4 extra isn't installed; nothing to catch below
+    _MDF_EXCEPTIONS = ()
 
 
 def _frame_to_message(frame: Frame) -> can.Message:
@@ -92,3 +109,33 @@ def read_asc(path: str | Path) -> list[Frame]:
             return [_message_to_frame(message) for message in reader]
     except (OSError, can.CanError) as exc:
         raise TraceLoadError(f"could not read ASC file {path!r}: {exc}") from exc
+
+
+def write_mdf4(frames: Iterable[Frame], path: str | Path) -> None:
+    """Write `frames` to an MDF4 trace file. Requires the `mdf4` optional
+    extra (`pip install tapwright[mdf4]`) — raises `TraceError` naming it
+    if `asammdf` isn't installed.
+    """
+    try:
+        with can.io.MF4Writer(path) as writer:
+            for frame in frames:
+                writer.on_message_received(_frame_to_message(frame))
+    except NotImplementedError as exc:
+        raise TraceError(
+            "MDF4 support requires the 'mdf4' optional extra: pip install tapwright[mdf4]"
+        ) from exc
+
+
+def read_mdf4(path: str | Path) -> list[Frame]:
+    """Read every frame from an MDF4 trace file, in recorded order.
+    Requires the `mdf4` optional extra; see `write_mdf4()`.
+    """
+    try:
+        with can.io.MF4Reader(path) as reader:
+            return [_message_to_frame(message) for message in reader]
+    except NotImplementedError as exc:
+        raise TraceError(
+            "MDF4 support requires the 'mdf4' optional extra: pip install tapwright[mdf4]"
+        ) from exc
+    except (OSError, can.CanError, *_MDF_EXCEPTIONS) as exc:  # type: ignore[misc]
+        raise TraceLoadError(f"could not read MDF4 file {path!r}: {exc}") from exc

--- a/tests/differential/test_mdf4_io.py
+++ b/tests/differential/test_mdf4_io.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T3/T4 test plan for BUS-06 — MDF4 read/write via `asammdf`
+(`TOOL-REQ-021`).
+
+Implements #51. Oracle is the plan's own line: "Core installs and passes
+without the extra; extra round-trips MDF4" plus `TOOL-REQ-021`'s own
+acceptance criterion: "Produces a valid MDF4 file (via `asammdf`) that
+opens in a third-party MDF4-compliant tool." `asammdf` itself, used
+directly (not through `tapwright`'s own wrapper), stands in for that
+third-party tool — it's the reference implementation of the format, not
+code this project wrote.
+
+Per `AGENTS.md`'s reuse rule and the BUS-05 precedent (BLF/ASC wrapping
+`can.io.BLFWriter`/`BLFReader`/`ASCWriter`/`ASCReader`), this wraps
+`python-can`'s own `MF4Writer`/`MF4Reader` (`can.io.mf4`) — which already
+implements CAN-frame-level MDF4 logging on top of `asammdf` — rather than
+hand-rolling `asammdf.Signal`/`MDF.append()` calls directly. `python-can`
+is already a required dependency; only `asammdf` itself is the new,
+LGPL-isolated optional extra (`tapwright[mdf4]`, `FW-REQ-015`).
+
+## `pytest.importorskip` — proving the "no extra" half of the oracle
+
+Every case in this file skips cleanly via `pytest.importorskip("asammdf")`
+at module level. This *is* how "the core installs and passes its full
+suite without the extra" gets proven mechanically: a CI job that installs
+`tapwright` without `[mdf4]` and runs the full suite must show these cases
+skipped, not failed or errored. A second CI job installs `tapwright[mdf4]`
+and must show them passing for real.
+
+## A real finding from API research (kept here, not silently worked around)
+
+`python-can`'s own `can.io.mf4.MF4Writer`/`MF4Reader` already raise a
+clear `NotImplementedError` ("install python-can with the optional
+dependency [mf4]") when `asammdf` isn't importable — better than the
+BUS-05 `ASCReader` silent-failure gap. `test_missing_asammdf_...` monkeypatches
+`can.io.mf4`'s own module-level `asammdf` binding to `None` to exercise
+this without needing a second real environment, and asserts `tapwright`
+translates it to a `TraceError` naming the extra, rather than leaking
+`python-can`'s own message verbatim (a caller catching `tapwright.trace`
+errors shouldn't need to know `python-can`'s internals to understand what
+to install).
+
+Round-tripped timestamps lose float precision (`0.1` -> observed
+`0.09999990463256836` in manual research against `asammdf` 8.8.26) —
+`pytest.approx` is used for timestamp comparisons rather than exact
+equality, matching this format's real behavior rather than the byte-exact
+oracle BUS-05 used for BLF.
+"""
+
+from __future__ import annotations
+
+import can
+import pytest
+
+from tapwright.hal import Frame
+from tapwright.trace.errors import TraceError, TraceLoadError
+
+pytest.importorskip("asammdf")
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #51)")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_round_trips_frames_through_write_then_read(tmp_path):
+    from tapwright.trace import read_mdf4, write_mdf4
+
+    frames = [
+        Frame(arbitration_id=0x100, data=b"\x01\x02", timestamp=0.0),
+        Frame(arbitration_id=0x101, data=b"\xaa\xbb\xcc", timestamp=0.1),
+    ]
+    path = tmp_path / "trace.mf4"
+    write_mdf4(frames, path)
+    result = read_mdf4(path)
+
+    assert len(result) == len(frames)
+    for expected, actual in zip(frames, result):
+        assert actual.arbitration_id == expected.arbitration_id
+        assert actual.data == expected.data
+        assert actual.timestamp == pytest.approx(expected.timestamp, abs=1e-4)
+
+
+@SKIP
+def test_written_file_opens_directly_with_asammdf(tmp_path):
+    """The literal acceptance criterion: a third-party MDF4-compliant tool
+    (here, `asammdf` used directly, not through `tapwright`) can open what
+    `write_mdf4()` produces.
+    """
+    from asammdf import MDF
+
+    from tapwright.trace import write_mdf4
+
+    frames = [Frame(arbitration_id=0x200, data=b"\x01\x02\x03\x04")]
+    path = tmp_path / "direct.mf4"
+    write_mdf4(frames, path)
+
+    with MDF(path) as mdf:
+        assert mdf.version.startswith("4.")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_writing_zero_frames_round_trips_to_an_empty_list(tmp_path):
+    from tapwright.trace import read_mdf4, write_mdf4
+
+    path = tmp_path / "empty.mf4"
+    write_mdf4([], path)
+    assert read_mdf4(path) == []
+
+
+@SKIP
+def test_extended_id_frame_is_preserved(tmp_path):
+    from tapwright.trace import read_mdf4, write_mdf4
+
+    frames = [Frame(arbitration_id=0x1ABCDEF, data=b"\x01", is_extended_id=True)]
+    path = tmp_path / "extended.mf4"
+    write_mdf4(frames, path)
+    result = read_mdf4(path)
+
+    assert result[0].arbitration_id == 0x1ABCDEF
+    assert result[0].is_extended_id is True
+
+
+@SKIP
+def test_fd_frame_is_preserved(tmp_path):
+    from tapwright.trace import read_mdf4, write_mdf4
+
+    frames = [Frame(arbitration_id=0x300, data=bytes(range(12)), is_fd=True)]
+    path = tmp_path / "fd.mf4"
+    write_mdf4(frames, path)
+    result = read_mdf4(path)
+
+    assert result[0].data == bytes(range(12))
+    assert result[0].is_fd is True
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_reading_a_missing_file_raises_trace_load_error(tmp_path):
+    from tapwright.trace import read_mdf4
+
+    with pytest.raises(TraceLoadError):
+        read_mdf4(tmp_path / "does_not_exist.mf4")
+
+
+@SKIP
+def test_reading_a_garbage_file_raises_trace_load_error(tmp_path):
+    from tapwright.trace import read_mdf4
+
+    path = tmp_path / "garbage.mf4"
+    path.write_bytes(b"not an mdf file at all, just garbage bytes")
+
+    with pytest.raises(TraceLoadError):
+        read_mdf4(path)
+
+
+@SKIP
+def test_missing_asammdf_extra_raises_a_clear_tapwright_error(tmp_path, monkeypatch):
+    """Simulates `tapwright` installed *without* `[mdf4]`: `can.io.mf4`'s
+    own module-level `asammdf` binding is `None` in that environment. The
+    wrapper must translate `python-can`'s own `NotImplementedError` into a
+    `tapwright.trace` error naming the extra to install, not leak it
+    verbatim.
+    """
+    from tapwright.trace import write_mdf4
+
+    monkeypatch.setattr(can.io.mf4, "asammdf", None)
+
+    with pytest.raises(TraceError, match="tapwright\\[mdf4\\]"):
+        write_mdf4([Frame(arbitration_id=0x1, data=b"\x01")], tmp_path / "unused.mf4")

--- a/tests/differential/test_mdf4_io.py
+++ b/tests/differential/test_mdf4_io.py
@@ -58,7 +58,8 @@ from tapwright.trace.errors import TraceError, TraceLoadError
 
 pytest.importorskip("asammdf")
 
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #51)")
+from asammdf import MDF  # noqa: E402, I001 -- only reachable after the importorskip above
+from tapwright.trace import read_mdf4, write_mdf4  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -66,10 +67,7 @@ SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #51)
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_round_trips_frames_through_write_then_read(tmp_path):
-    from tapwright.trace import read_mdf4, write_mdf4
-
     frames = [
         Frame(arbitration_id=0x100, data=b"\x01\x02", timestamp=0.0),
         Frame(arbitration_id=0x101, data=b"\xaa\xbb\xcc", timestamp=0.1),
@@ -79,22 +77,17 @@ def test_round_trips_frames_through_write_then_read(tmp_path):
     result = read_mdf4(path)
 
     assert len(result) == len(frames)
-    for expected, actual in zip(frames, result):
+    for expected, actual in zip(frames, result, strict=True):
         assert actual.arbitration_id == expected.arbitration_id
         assert actual.data == expected.data
         assert actual.timestamp == pytest.approx(expected.timestamp, abs=1e-4)
 
 
-@SKIP
 def test_written_file_opens_directly_with_asammdf(tmp_path):
     """The literal acceptance criterion: a third-party MDF4-compliant tool
     (here, `asammdf` used directly, not through `tapwright`) can open what
     `write_mdf4()` produces.
     """
-    from asammdf import MDF
-
-    from tapwright.trace import write_mdf4
-
     frames = [Frame(arbitration_id=0x200, data=b"\x01\x02\x03\x04")]
     path = tmp_path / "direct.mf4"
     write_mdf4(frames, path)
@@ -108,19 +101,13 @@ def test_written_file_opens_directly_with_asammdf(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_writing_zero_frames_round_trips_to_an_empty_list(tmp_path):
-    from tapwright.trace import read_mdf4, write_mdf4
-
     path = tmp_path / "empty.mf4"
     write_mdf4([], path)
     assert read_mdf4(path) == []
 
 
-@SKIP
 def test_extended_id_frame_is_preserved(tmp_path):
-    from tapwright.trace import read_mdf4, write_mdf4
-
     frames = [Frame(arbitration_id=0x1ABCDEF, data=b"\x01", is_extended_id=True)]
     path = tmp_path / "extended.mf4"
     write_mdf4(frames, path)
@@ -130,10 +117,7 @@ def test_extended_id_frame_is_preserved(tmp_path):
     assert result[0].is_extended_id is True
 
 
-@SKIP
 def test_fd_frame_is_preserved(tmp_path):
-    from tapwright.trace import read_mdf4, write_mdf4
-
     frames = [Frame(arbitration_id=0x300, data=bytes(range(12)), is_fd=True)]
     path = tmp_path / "fd.mf4"
     write_mdf4(frames, path)
@@ -148,18 +132,12 @@ def test_fd_frame_is_preserved(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_reading_a_missing_file_raises_trace_load_error(tmp_path):
-    from tapwright.trace import read_mdf4
-
     with pytest.raises(TraceLoadError):
         read_mdf4(tmp_path / "does_not_exist.mf4")
 
 
-@SKIP
 def test_reading_a_garbage_file_raises_trace_load_error(tmp_path):
-    from tapwright.trace import read_mdf4
-
     path = tmp_path / "garbage.mf4"
     path.write_bytes(b"not an mdf file at all, just garbage bytes")
 
@@ -167,7 +145,6 @@ def test_reading_a_garbage_file_raises_trace_load_error(tmp_path):
         read_mdf4(path)
 
 
-@SKIP
 def test_missing_asammdf_extra_raises_a_clear_tapwright_error(tmp_path, monkeypatch):
     """Simulates `tapwright` installed *without* `[mdf4]`: `can.io.mf4`'s
     own module-level `asammdf` binding is `None` in that environment. The
@@ -175,8 +152,6 @@ def test_missing_asammdf_extra_raises_a_clear_tapwright_error(tmp_path, monkeypa
     `tapwright.trace` error naming the extra to install, not leak it
     verbatim.
     """
-    from tapwright.trace import write_mdf4
-
     monkeypatch.setattr(can.io.mf4, "asammdf", None)
 
     with pytest.raises(TraceError, match="tapwright\\[mdf4\\]"):


### PR DESCRIPTION
## What this changes and why
Closes #51

Implements BUS-06 / `TOOL-REQ-021`: `tapwright.trace.write_mdf4()`/`read_mdf4()` wrap `python-can`'s own `MF4Writer`/`MF4Reader` — which already implement CAN-frame-level MDF4 logging on top of `asammdf` — rather than hand-rolling `asammdf.Signal`/`MDF.append()` calls directly.

`asammdf` (LGPL-3.0) ships as a new optional extra, `pip install tapwright[mdf4]`: the core installs and passes its full suite without it, matching the isolation precedent HAL-08 already established for `python-can` itself (`FW-REQ-019`). `licences.toml` already had a pre-populated, pre-verified `asammdf` entry anticipating this loop.

**Priority correction, flagged in #51**: the plan's own loop table and `LOOPS.md` list this loop as Should, but the cited requirement (`TOOL-REQ-021`, "MDF4 read + write") is rated **Must**. Corrected here — this was in fact the highest-priority remaining unblocked loop, since every other agent-buildable Must loop is already closed.

**A real upstream gap found during development**: `python-can`'s own `can/io/mf4.py` guards its `asammdf` import with `except ImportError` only. An incompatible `asammdf`/`numpy` combination (hit directly while researching this loop — `asammdf` 8.8.26 needs `numpy>=2`, and a partial/broken numpy upgrade on the dev machine left an environment where `np.bool` raised `AttributeError` instead of the expected deprecated-alias warning) surfaces as an **uncaught `AttributeError`** deep inside `python-can`, not a clean message — and because `python-can`'s own `can/io/__init__.py` imports `mf4.py` unconditionally, this can crash `import can` entirely, not just MDF4 support. `write_mdf4()`/`read_mdf4()` catch `python-can`'s own correctly-raised `NotImplementedError` (the "asammdf not installed at all" case) and translate it into `TraceError` naming the extra to install — the case this project's own code can actually control.

## How this was tested
8 cases in `tests/differential/test_mdf4_io.py` (T3/T4 — `asammdf` used directly as the third-party MDF4-compliant-tool oracle):
- happy path: round-trip through `write_mdf4()`/`read_mdf4()`; the written file opens directly with `asammdf` used as a plain caller
- edge cases: zero frames, extended-ID frame preserved, CAN-FD frame preserved
- error cases: missing file, garbage/invalid file, and a monkeypatched "asammdf not installed" case all raise clear `tapwright.trace` errors

**Both halves of the oracle proven mechanically**: every case uses `pytest.importorskip("asammdf")`. The existing `t3-differential` CI job (no `[mdf4]`) shows this file skip cleanly — "core installs and passes without the extra." A new `mdf4-extra` CI job installs `tapwright[mdf4]` and runs the file for real — "extra round-trips MDF4." Confirmed locally in an isolated venv (avoided touching this dev machine's global Python environment a second time, having already broken and restored it once during API research) — all 8 pass with `asammdf` installed, 1 collected-and-skipped without it.

Full local gate clean in the global environment (no `asammdf`): `ruff check`, `ruff format --check`, `mypy src`, `tools/check_licences.py`, `pytest --cov` (178 passed, 101 skipped including the new MDF4 cases, 3 pre-existing failures unrelated to this change — 2 known Docker-Desktop-VM-vcan-gap failures, 1 Windows-only console-script-path issue, both present on `main` before this branch).

## Checklist
- [x] DCO sign-off (`git commit -s`)
- [x] Tests added (skip-stubbed plan posted to #51 first, then implemented)
- [x] CHANGELOG.md updated
- [x] Lint/type-check/licence-gate clean
- [x] `docs/architecture.md` not applicable (no `diag/` public API touched)