### PR TITLE
feat(runner): add deterministic wait helpers (RUN-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- **Deterministic wait helpers** (RUN-10, `TOOL-REQ-029`; #53):
+  `tapwright.runner.wait.wait_for_message()`/`wait_for_signal()`/
+  `wait_for_response()` — a test polling for a bus event or a diagnostic
+  response no longer needs a hand-rolled sleep/retry loop. All three raise
+  a new `WaitTimeoutError` on timeout rather than returning `None` or
+  silently giving up. `CanDatabase` gains a small `frame_id()` helper
+  (arbitration ID + extended-ID flag for a named message), used by
+  `wait_for_signal()` to filter incoming frames by message identity before
+  decoding, so a frame from an unrelated message can never be
+  misattributed even if it happens to share a signal name. **New loop, not
+  one of the plan's original 37**: `TOOL-REQ-029` is Must-priority and
+  named directly in `docs/architecture.md`'s `NFR-003`, but no loop in the
+  plan's own table ever covered it — RUN-01 explicitly flagged this gap
+  when it shipped without it, and this closes it.
 - **MDF4 trace read/write** (BUS-06, `TOOL-REQ-021`; #51):
   `tapwright.trace.write_mdf4()`/`read_mdf4()`, wrapping `python-can`'s own
   `MF4Writer`/`MF4Reader` (which already implement CAN-frame-level MDF4

--- a/src/tapwright/dbc_arxml/database.py
+++ b/src/tapwright/dbc_arxml/database.py
@@ -112,6 +112,23 @@ class CanDatabase:
             return None
         return message.cycle_time / 1000.0
 
+    def frame_id(self, message_name: str) -> tuple[int, bool]:
+        """The named message's `(arbitration_id, is_extended_id)` — used by
+        `tapwright.runner.wait.wait_for_signal` (`TOOL-REQ-029`) to filter
+        incoming frames by message identity before decoding them, rather
+        than matching on decoded signal name alone (which could
+        misattribute a frame from an unrelated message that happens to
+        share a signal name).
+        """
+        try:
+            message = self._db.get_message_by_name(message_name)
+        except KeyError as exc:
+            raise UnknownMessageError(
+                f"no message named {message_name!r} in this database"
+            ) from exc
+
+        return message.frame_id, message.is_extended_frame
+
 
 def _load(path: str | Path, database_format: str) -> CanDatabase:
     """Shared load path for `load_dbc()`/`load_arxml()`. `database_format`

--- a/src/tapwright/runner/__init__.py
+++ b/src/tapwright/runner/__init__.py
@@ -5,14 +5,14 @@
 Tests are plain pytest — this module is the fixture layer, not a custom
 runner. See ARCHITECTURE.md at the repository root.
 
-Implemented so far: `plugin.py` (RUN-01, `TOOL-REQ-028`) — the `ecu`, `bus`,
-`uds` fixtures, registered as a `pytest11` entry point in `pyproject.toml`
-so they're auto-discovered on `pip install tapwright`, no
-`pytest_plugins = [...]` needed. Not imported here: pytest discovers plugin
-modules via the entry point directly, not via `tapwright.runner`'s own
-import graph.
-
-Not yet implemented: deterministic `wait_for_*` helpers (`TOOL-REQ-029`,
-a separate requirement from RUN-01's three fixtures), CLI entrypoints
-(RUN-05), reports (RUN-03/04).
+Implemented so far: `plugin.py` (RUN-01, `TOOL-REQ-028`; RUN-03/04 report
+auto-enable) — the `ecu`, `bus`, `uds` fixtures, registered as a `pytest11`
+entry point in `pyproject.toml` so they're auto-discovered on
+`pip install tapwright`, no `pytest_plugins = [...]` needed. `cli.py`
+(RUN-05, `TOOL-REQ-030`) — the unified CLI entry point. `wait.py` (RUN-10,
+`TOOL-REQ-029`) — `wait_for_message()`/`wait_for_signal()`/
+`wait_for_response()`. None of these are imported here: pytest discovers
+`plugin.py` via the entry point directly, `cli.py`/`wait.py` are imported
+directly by name (`from tapwright.runner.wait import ...`), not via
+`tapwright.runner`'s own import graph.
 """

--- a/src/tapwright/runner/wait.py
+++ b/src/tapwright/runner/wait.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic wait helpers (RUN-10, `TOOL-REQ-029`).
+
+`wait_for_message()`/`wait_for_signal()`/`wait_for_response()` replace
+hand-rolled sleep/retry loops around a bus event or a diagnostic response
+with a single call that raises `WaitTimeoutError` on timeout instead of
+looping forever or silently giving up — the "no silent failure" convention
+`hal.errors.CapabilityError` already established.
+
+No library to wrap here per `AGENTS.md`'s reuse-first rule: this is
+project-specific glue over `tapwright`'s own `hal.Frame`/
+`dbc_arxml.CanDatabase` types, not a reimplementation of anything
+`python-can`/`cantools`/`udsoncan` already provide.
+
+`wait_for_message()` needs no artificial polling interval: `hal.Bus.recv()`
+already blocks up to its own `timeout` argument, so each call either
+returns a candidate frame or the deadline has passed — no `time.sleep()`
+anywhere in that path. `wait_for_response()` polls an arbitrary callable
+instead of a bus, which has no equivalent blocking primitive, so it uses
+`poll_interval` between calls.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from tapwright.hal import Frame
+
+if TYPE_CHECKING:
+    from tapwright.dbc_arxml import CanDatabase
+    from tapwright.hal import Bus
+
+T = TypeVar("T")
+
+
+class WaitTimeoutError(Exception):
+    """Raised by `wait_for_message()`/`wait_for_signal()`/
+    `wait_for_response()` when their condition never became true within
+    the given timeout."""
+
+
+def wait_for_message(
+    bus: Bus,
+    timeout: float,
+    predicate: Callable[[Frame], bool] | None = None,
+) -> Frame:
+    """Block until a `Frame` satisfying `predicate` is received on `bus`,
+    or raise `WaitTimeoutError` after `timeout` seconds.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WaitTimeoutError(f"no matching frame received within {timeout}s")
+        frame = bus.recv(timeout=remaining)
+        if frame is not None and (predicate is None or predicate(frame)):
+            return frame
+
+
+def wait_for_signal(
+    bus: Bus,
+    db: CanDatabase,
+    message_name: str,
+    signal_name: str,
+    predicate: Callable[[Any], bool],
+    timeout: float,
+) -> Any:
+    """Block until `message_name`'s `signal_name`, decoded via `db`,
+    satisfies `predicate`, or raise `WaitTimeoutError` after `timeout`
+    seconds.
+
+    Filters incoming frames by `message_name`'s own arbitration ID (via
+    `db.frame_id()`) before decoding, so a frame from an unrelated message
+    can never be misattributed even if it happens to decode a same-named
+    signal.
+    """
+    frame_id, is_extended_id = db.frame_id(message_name)
+
+    def matches(frame: Frame) -> bool:
+        if frame.arbitration_id != frame_id or frame.is_extended_id != is_extended_id:
+            return False
+        decoded = db.decode(frame)
+        return signal_name in decoded and predicate(decoded[signal_name])
+
+    frame = wait_for_message(bus, timeout=timeout, predicate=matches)
+    return db.decode(frame)[signal_name]
+
+
+def wait_for_response(
+    call: Callable[[], T],
+    predicate: Callable[[T], bool],
+    timeout: float,
+    poll_interval: float = 0.05,
+) -> T:
+    """Call `call()` repeatedly until its result satisfies `predicate`, or
+    raise `WaitTimeoutError` after `timeout` seconds.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        result = call()
+        if predicate(result):
+            return result
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WaitTimeoutError(f"predicate never matched within {timeout}s")
+        time.sleep(min(poll_interval, remaining))

--- a/tests/integration/test_wait_helpers.py
+++ b/tests/integration/test_wait_helpers.py
@@ -1,19 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""T2 test plan for RUN-10 — deterministic wait helpers (`TOOL-REQ-029`).
+"""T2 tests for `wait_for_message()`/`wait_for_signal()` (RUN-10,
+`TOOL-REQ-029`).
 
 Implements #53. Oracle per `NFR-003`: no flakiness under normal CI timing
 variance — proven here by exercising both the "found before timeout" and
-"genuinely times out" paths for all three helpers against real `vcan`.
+"genuinely times out" paths against real `vcan`.
 
 RUN-10 is a new loop, not one of the plan's original 37 — `TOOL-REQ-029`
 was explicitly flagged as out of scope during RUN-01 (see `LOOPS.md`) and
 never picked up since; see issue #53 for the full gap writeup.
 
-`wait_for_message()`/`wait_for_signal()`/`wait_for_response()` all raise
-one new `WaitTimeoutError` on timeout, matching this project's established
-"no silent failure" convention (`hal.errors.CapabilityError`'s own
-precedent; the BUS-05 `ASCReader` hardening fix).
+`wait_for_response()`'s tests live in `tests/unit/test_wait_response.py`
+instead — it polls an arbitrary callable, not a bus, so it needs no
+`vcan` and shouldn't be gated behind it.
 
 Reuses `fixtures/databases/cyclic.dbc` (BUS-07's self-authored fixture) —
 `EngineData` (frame ID `0x100`, `EngineSpeed`/`EngineTemp` signals) is
@@ -27,8 +27,7 @@ import pytest
 
 from tapwright.dbc_arxml import load_dbc
 from tapwright.hal import Frame, open_bus
-
-SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #53)")
+from tapwright.runner.wait import WaitTimeoutError, wait_for_message, wait_for_signal
 
 pytestmark = pytest.mark.requires_vcan
 
@@ -40,10 +39,7 @@ FIXTURES_DBC = "fixtures/databases/cyclic.dbc"
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_wait_for_message_returns_the_first_matching_frame(vcan_channel):
-    from tapwright.runner.wait import wait_for_message
-
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
     try:
@@ -57,10 +53,7 @@ def test_wait_for_message_returns_the_first_matching_frame(vcan_channel):
         receiver.shutdown()
 
 
-@SKIP
 def test_wait_for_signal_returns_the_decoded_value_once_the_predicate_matches(vcan_channel):
-    from tapwright.runner.wait import wait_for_signal
-
     db = load_dbc(FIXTURES_DBC)
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
@@ -77,24 +70,12 @@ def test_wait_for_signal_returns_the_decoded_value_once_the_predicate_matches(vc
         receiver.shutdown()
 
 
-@SKIP
-def test_wait_for_response_retries_the_callable_until_the_predicate_matches():
-    from tapwright.runner.wait import wait_for_response
-
-    calls = iter([1, 2, 3])
-    result = wait_for_response(lambda: next(calls), predicate=lambda v: v == 3, timeout=1.0, poll_interval=0.01)
-    assert result == 3
-
-
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_wait_for_message_returns_immediately_when_first_frame_already_matches(vcan_channel):
-    from tapwright.runner.wait import wait_for_message
-
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
     try:
@@ -106,15 +87,12 @@ def test_wait_for_message_returns_immediately_when_first_frame_already_matches(v
         receiver.shutdown()
 
 
-@SKIP
 def test_wait_for_signal_keeps_polling_past_an_unrelated_frame(vcan_channel):
     """An unrelated frame ID arriving first must not cause `wait_for_signal`
     to error or falsely resolve — exercises the "keep polling past
     non-matching arbitration IDs" path directly, not just "signal value
     not yet right."
     """
-    from tapwright.runner.wait import wait_for_signal
-
     db = load_dbc(FIXTURES_DBC)
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
@@ -131,33 +109,12 @@ def test_wait_for_signal_keeps_polling_past_an_unrelated_frame(vcan_channel):
         receiver.shutdown()
 
 
-@SKIP
-def test_wait_for_response_honors_poll_interval_bounding_call_count():
-    from tapwright.runner.wait import WaitTimeoutError, wait_for_response
-
-    calls = []
-
-    def call():
-        calls.append(1)
-        return False
-
-    with pytest.raises(WaitTimeoutError):
-        wait_for_response(call, predicate=lambda v: v is True, timeout=0.2, poll_interval=0.05)
-
-    # ~4 polls expected at 0.2s/0.05s; a wide band tolerant of CI scheduler
-    # jitter, proving it isn't busy-looping (which would be hundreds of calls).
-    assert 1 <= len(calls) <= 10
-
-
 # ---------------------------------------------------------------------------
 # Error cases
 # ---------------------------------------------------------------------------
 
 
-@SKIP
 def test_wait_for_message_raises_wait_timeout_error_when_nothing_matches(vcan_channel):
-    from tapwright.runner.wait import WaitTimeoutError, wait_for_message
-
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
     try:
         with pytest.raises(WaitTimeoutError):
@@ -166,10 +123,7 @@ def test_wait_for_message_raises_wait_timeout_error_when_nothing_matches(vcan_ch
         receiver.shutdown()
 
 
-@SKIP
 def test_wait_for_signal_raises_wait_timeout_error_when_predicate_never_matches(vcan_channel):
-    from tapwright.runner.wait import WaitTimeoutError, wait_for_signal
-
     db = load_dbc(FIXTURES_DBC)
     sender = open_bus(backend="socketcan", channel=vcan_channel)
     receiver = open_bus(backend="socketcan", channel=vcan_channel)
@@ -177,16 +131,13 @@ def test_wait_for_signal_raises_wait_timeout_error_when_predicate_never_matches(
         sender.send(db.encode("EngineData", {"EngineSpeed": 1.0, "EngineTemp": 0}))
         with pytest.raises(WaitTimeoutError):
             wait_for_signal(
-                receiver, db, "EngineData", "EngineSpeed", predicate=lambda v: v > 999999, timeout=0.3
+                receiver,
+                db,
+                "EngineData",
+                "EngineSpeed",
+                predicate=lambda v: v > 999999,
+                timeout=0.3,
             )
     finally:
         sender.shutdown()
         receiver.shutdown()
-
-
-@SKIP
-def test_wait_for_response_raises_wait_timeout_error_when_predicate_never_matches():
-    from tapwright.runner.wait import WaitTimeoutError, wait_for_response
-
-    with pytest.raises(WaitTimeoutError):
-        wait_for_response(lambda: False, predicate=lambda v: v is True, timeout=0.2, poll_interval=0.05)

--- a/tests/integration/test_wait_helpers.py
+++ b/tests/integration/test_wait_helpers.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T2 test plan for RUN-10 — deterministic wait helpers (`TOOL-REQ-029`).
+
+Implements #53. Oracle per `NFR-003`: no flakiness under normal CI timing
+variance — proven here by exercising both the "found before timeout" and
+"genuinely times out" paths for all three helpers against real `vcan`.
+
+RUN-10 is a new loop, not one of the plan's original 37 — `TOOL-REQ-029`
+was explicitly flagged as out of scope during RUN-01 (see `LOOPS.md`) and
+never picked up since; see issue #53 for the full gap writeup.
+
+`wait_for_message()`/`wait_for_signal()`/`wait_for_response()` all raise
+one new `WaitTimeoutError` on timeout, matching this project's established
+"no silent failure" convention (`hal.errors.CapabilityError`'s own
+precedent; the BUS-05 `ASCReader` hardening fix).
+
+Reuses `fixtures/databases/cyclic.dbc` (BUS-07's self-authored fixture) —
+`EngineData` (frame ID `0x100`, `EngineSpeed`/`EngineTemp` signals) is
+exactly the shape `wait_for_signal()`'s tests need; no new fixture
+required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tapwright.dbc_arxml import load_dbc
+from tapwright.hal import Frame, open_bus
+
+SKIP = pytest.mark.skip(reason="test plan — implementation pending (issue #53)")
+
+pytestmark = pytest.mark.requires_vcan
+
+FIXTURES_DBC = "fixtures/databases/cyclic.dbc"
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_wait_for_message_returns_the_first_matching_frame(vcan_channel):
+    from tapwright.runner.wait import wait_for_message
+
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        sender.send(Frame(arbitration_id=0x1, data=b"\x00"))  # non-matching, sent first
+        sender.send(Frame(arbitration_id=0x2, data=b"\x01"))  # matching
+
+        frame = wait_for_message(receiver, timeout=1.0, predicate=lambda f: f.arbitration_id == 0x2)
+        assert frame.arbitration_id == 0x2
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+@SKIP
+def test_wait_for_signal_returns_the_decoded_value_once_the_predicate_matches(vcan_channel):
+    from tapwright.runner.wait import wait_for_signal
+
+    db = load_dbc(FIXTURES_DBC)
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        sender.send(db.encode("EngineData", {"EngineSpeed": 100.0, "EngineTemp": 20}))
+        sender.send(db.encode("EngineData", {"EngineSpeed": 5000.0, "EngineTemp": 90}))
+
+        value = wait_for_signal(
+            receiver, db, "EngineData", "EngineSpeed", predicate=lambda v: v >= 5000.0, timeout=1.0
+        )
+        assert value == 5000.0
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+@SKIP
+def test_wait_for_response_retries_the_callable_until_the_predicate_matches():
+    from tapwright.runner.wait import wait_for_response
+
+    calls = iter([1, 2, 3])
+    result = wait_for_response(lambda: next(calls), predicate=lambda v: v == 3, timeout=1.0, poll_interval=0.01)
+    assert result == 3
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_wait_for_message_returns_immediately_when_first_frame_already_matches(vcan_channel):
+    from tapwright.runner.wait import wait_for_message
+
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        sender.send(Frame(arbitration_id=0x5, data=b"\x00"))
+        frame = wait_for_message(receiver, timeout=1.0, predicate=lambda f: f.arbitration_id == 0x5)
+        assert frame.arbitration_id == 0x5
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+@SKIP
+def test_wait_for_signal_keeps_polling_past_an_unrelated_frame(vcan_channel):
+    """An unrelated frame ID arriving first must not cause `wait_for_signal`
+    to error or falsely resolve — exercises the "keep polling past
+    non-matching arbitration IDs" path directly, not just "signal value
+    not yet right."
+    """
+    from tapwright.runner.wait import wait_for_signal
+
+    db = load_dbc(FIXTURES_DBC)
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        sender.send(Frame(arbitration_id=0x999, data=b"\x00" * 8))  # unrelated frame ID
+        sender.send(db.encode("EngineData", {"EngineSpeed": 42.0, "EngineTemp": 0}))
+
+        value = wait_for_signal(
+            receiver, db, "EngineData", "EngineSpeed", predicate=lambda v: v == 42.0, timeout=1.0
+        )
+        assert value == 42.0
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+@SKIP
+def test_wait_for_response_honors_poll_interval_bounding_call_count():
+    from tapwright.runner.wait import WaitTimeoutError, wait_for_response
+
+    calls = []
+
+    def call():
+        calls.append(1)
+        return False
+
+    with pytest.raises(WaitTimeoutError):
+        wait_for_response(call, predicate=lambda v: v is True, timeout=0.2, poll_interval=0.05)
+
+    # ~4 polls expected at 0.2s/0.05s; a wide band tolerant of CI scheduler
+    # jitter, proving it isn't busy-looping (which would be hundreds of calls).
+    assert 1 <= len(calls) <= 10
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@SKIP
+def test_wait_for_message_raises_wait_timeout_error_when_nothing_matches(vcan_channel):
+    from tapwright.runner.wait import WaitTimeoutError, wait_for_message
+
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        with pytest.raises(WaitTimeoutError):
+            wait_for_message(receiver, timeout=0.3, predicate=lambda f: False)
+    finally:
+        receiver.shutdown()
+
+
+@SKIP
+def test_wait_for_signal_raises_wait_timeout_error_when_predicate_never_matches(vcan_channel):
+    from tapwright.runner.wait import WaitTimeoutError, wait_for_signal
+
+    db = load_dbc(FIXTURES_DBC)
+    sender = open_bus(backend="socketcan", channel=vcan_channel)
+    receiver = open_bus(backend="socketcan", channel=vcan_channel)
+    try:
+        sender.send(db.encode("EngineData", {"EngineSpeed": 1.0, "EngineTemp": 0}))
+        with pytest.raises(WaitTimeoutError):
+            wait_for_signal(
+                receiver, db, "EngineData", "EngineSpeed", predicate=lambda v: v > 999999, timeout=0.3
+            )
+    finally:
+        sender.shutdown()
+        receiver.shutdown()
+
+
+@SKIP
+def test_wait_for_response_raises_wait_timeout_error_when_predicate_never_matches():
+    from tapwright.runner.wait import WaitTimeoutError, wait_for_response
+
+    with pytest.raises(WaitTimeoutError):
+        wait_for_response(lambda: False, predicate=lambda v: v is True, timeout=0.2, poll_interval=0.05)

--- a/tests/unit/test_wait_response.py
+++ b/tests/unit/test_wait_response.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""T1 tests for `wait_for_response()` (RUN-10, `TOOL-REQ-029`).
+
+Split out from `tests/integration/test_wait_helpers.py`: unlike
+`wait_for_message()`/`wait_for_signal()`, `wait_for_response()` polls an
+arbitrary callable, not a bus — no `vcan` needed, so these run as plain
+unit tests rather than being needlessly gated behind `requires_vcan`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tapwright.runner.wait import WaitTimeoutError, wait_for_response
+
+
+def test_wait_for_response_retries_the_callable_until_the_predicate_matches():
+    calls = iter([1, 2, 3])
+    result = wait_for_response(
+        lambda: next(calls), predicate=lambda v: v == 3, timeout=1.0, poll_interval=0.01
+    )
+    assert result == 3
+
+
+def test_wait_for_response_honors_poll_interval_bounding_call_count():
+    calls = []
+
+    def call():
+        calls.append(1)
+        return False
+
+    with pytest.raises(WaitTimeoutError):
+        wait_for_response(call, predicate=lambda v: v is True, timeout=0.2, poll_interval=0.05)
+
+    # ~4 polls expected at 0.2s/0.05s; a wide band tolerant of CI scheduler
+    # jitter, proving it isn't busy-looping (which would be hundreds of calls).
+    assert 1 <= len(calls) <= 10
+
+
+def test_wait_for_response_raises_wait_timeout_error_when_predicate_never_matches():
+    with pytest.raises(WaitTimeoutError):
+        wait_for_response(
+            lambda: False, predicate=lambda v: v is True, timeout=0.2, poll_interval=0.05
+        )


### PR DESCRIPTION
## What this changes and why
Closes #53

Implements RUN-10 / `TOOL-REQ-029`: `wait_for_message()`/`wait_for_signal()`/`wait_for_response()` let a test poll for a bus event or a diagnostic response without a hand-rolled sleep/retry loop. All three raise a new `WaitTimeoutError` on timeout rather than returning `None` or silently giving up, matching this project's established "no silent failure" convention.

**This is a new loop, not one of the plan's original 37** — flagged in #53. `TOOL-REQ-029` is Must-priority and named directly in `docs/architecture.md`'s `NFR-003` ("The virtual-ECU + wait-helper combination... must produce non-flaky CI runs"), but no loop in the plan's own 37-loop table ever covered it. RUN-01's own closeout note in `LOOPS.md` already flagged this gap explicitly when it shipped without it: "DoIP fixtures and `TOOL-REQ-029`... are both explicitly out of scope, flagged as fast-follows rather than silently dropped." This PR is that fast-follow.

`CanDatabase` gains a small `frame_id()` helper (arbitration ID + extended-ID flag for a named message) — used by `wait_for_signal()` to filter incoming frames by message identity before decoding, so a frame from an unrelated message can never be misattributed even if it happens to share a signal name.

`wait_for_message()` needs no artificial polling interval: `hal.Bus.recv()` already blocks up to its own `timeout`, so each call either returns a candidate frame or the deadline has passed. `wait_for_response()` polls an arbitrary callable instead, which has no equivalent blocking primitive, so it sleeps between calls via `poll_interval`.

## How this was tested
9 cases total, split by tier:
- `tests/unit/test_wait_response.py` (T1, 3 cases) — `wait_for_response()` polls an arbitrary callable, not a bus, so it needs no `vcan` and isn't gated behind `requires_vcan`. All 3 run and pass locally.
- `tests/integration/test_wait_helpers.py` (T2, 6 cases, `vcan`-gated) — happy path, edge cases (return-immediately-if-already-matching, keep-polling-past-an-unrelated-frame), and error cases (timeout) for `wait_for_message()`/`wait_for_signal()`.

Since this dev machine has no `vcan`, the T2 cases skip locally (expected, verified only in CI per this repo's established pattern) — sanity-checked the core polling logic directly against a fake `Bus` stand-in and against a real `CanDatabase.frame_id()`/`encode()`/`decode()` round trip before pushing, to catch obvious bugs ahead of CI.

Full local gate clean: `ruff check`, `ruff format --check`, `mypy src`, `pytest --cov` — 180 passed, 107 skipped (including the new T2 cases), 4 pre-existing failures unrelated to this change (2 known Docker-Desktop-VM-`vcan`-gap failures, 1 Windows-only console-script-path issue, 1 Windows-only DIAG-05 cross-process socket-timing flake — confirmed present on `main` before this branch via `git stash`).

## Checklist
- [x] DCO sign-off (`git commit -s`)
- [x] Tests added (skip-stubbed plan posted to #53 first, then implemented)
- [x] CHANGELOG.md updated
- [x] Lint/type-check clean
- [x] `docs/architecture.md` not applicable (no `diag/` public API touched)